### PR TITLE
refactor: 카카오 소셜 로그인 구현 (#5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// 소셜 로그인 관련 설정
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// DB 설정
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 
 ext {
 	swaggerVersion="2.2.0";
+	gsonVersion="2.10.1";
 }
 
 
@@ -33,6 +34,7 @@ dependencies {
 	// 소셜 로그인 관련 설정
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation "com.google.code.gson:gson:${gsonVersion}"
 
 	// DB 설정
 	runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// Swagger 설정
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${swaggerVersion}"
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig{
         http
                 .authorizeHttpRequests(
                         request -> request.requestMatchers("/api/admin").permitAll()
+                                .requestMatchers("/login/*").permitAll()
                 )
                 .cors().configurationSource(corsConfigurationSource()); // cors 설정
 

--- a/src/main/java/com/beside/archivist/config/WebClientConfig.java
+++ b/src/main/java/com/beside/archivist/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.beside.archivist.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
+++ b/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
@@ -3,20 +3,8 @@ package com.beside.archivist.controller;
 
 import com.beside.archivist.dto.KakaoLoginDto;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
-
-import java.util.HashMap;
-import java.util.Map;
-
-
 import com.beside.archivist.service.KakaoService;
 
 @RestController
@@ -25,16 +13,10 @@ public class KakaoLoginController {
 
     private final KakaoService kakaoServiceImpl;
 
-    @GetMapping("/login/kakao")
-    public ResponseEntity<?> callback(@RequestParam("code") String code) throws IOException {
+    @PostMapping("/login/kakao")
+    public ResponseEntity<?> callback(@RequestParam("code") String code){
         String accessToken = kakaoServiceImpl.getAccessTokenFromKakao(code);
         KakaoLoginDto userInfo = kakaoServiceImpl.getUserInfo(accessToken);
         return ResponseEntity.ok().body(userInfo); // User 데이터
-    }
-
-    /* TEST 인가 코드 받는 엔드 포인트 */
-    @GetMapping("/sigin-callback")
-    public String callback2(@RequestParam("code") String code) {
-        return code;
     }
 }

--- a/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
+++ b/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
@@ -1,0 +1,98 @@
+package com.beside.archivist.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+
+import com.beside.archivist.service.KakaoService;
+/*
+import com.beside.archivist.service.HttpSessionOAuth2AuthorizedClientRepository;
+import com.beside.archivist.service.KakaoService;
+import com.beside.archivist.service.OAuth2User;
+import com.beside.archivist.service.OAuth2UserRequest;
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Client;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;*/
+
+
+
+@Slf4j
+@RestController
+@RequestMapping("")
+public class KakaoLoginController {
+	
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Value("${kakao.client_id}")
+    private String client_id;
+
+    @Autowired
+    private KakaoService kakaoService;
+
+    @GetMapping("/sigin-callback")
+    public String callback(@RequestParam("code") String code) throws IOException {
+    	
+    	System.out.println("code ====="+code);
+        String accessToken = kakaoService.getAccessTokenFromKakao(client_id, code);
+        HashMap<String, Object> userInfo = kakaoService.getUserInfo(accessToken);
+        log.info("id : " + userInfo.get("id"));
+        // User 데이터
+        return userInfo.toString();
+    }
+    
+    public String createAccessToken(long userId) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + Duration.ofHours(2).toMillis());
+        return Jwts.builder()
+                .claim("userId", userId)
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(SignatureAlgorithm.HS256, /*Secrets.JWT_ACCESS_SECRET_KEY*/"??")
+                .compact();
+    }
+    
+    
+	/*
+	 * @Bean public OAuth2UserService<OAuth2UserRequest, OAuth2User>
+	 * oauth2UserService(OAuth2AuthorizedClientRepository clientRepository) {
+	 * DefaultOAuth2UserService delegate = new DefaultOAuth2UserService(); return
+	 * request -> { OAuth2User user = delegate.loadUser(request); // 커스텀 로직 추가
+	 * return user; }; }
+	 * 
+	 * @Bean public OAuth2AuthorizedClientRepository authorizedClientRepository() {
+	 * return new HttpSessionOAuth2AuthorizedClientRepository(); }
+	 */
+}

--- a/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
+++ b/src/main/java/com/beside/archivist/controller/KakaoLoginController.java
@@ -1,98 +1,40 @@
 package com.beside.archivist.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-
-
-
+import com.beside.archivist.dto.KakaoLoginDto;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.time.Duration;
-import java.util.Date;
+
 import java.util.HashMap;
 import java.util.Map;
 
 
 import com.beside.archivist.service.KakaoService;
-/*
-import com.beside.archivist.service.HttpSessionOAuth2AuthorizedClientRepository;
-import com.beside.archivist.service.KakaoService;
-import com.beside.archivist.service.OAuth2User;
-import com.beside.archivist.service.OAuth2UserRequest;
-import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Client;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;*/
 
-
-
-@Slf4j
 @RestController
-@RequestMapping("")
+@RequiredArgsConstructor
 public class KakaoLoginController {
-	
-	private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @Value("${kakao.client_id}")
-    private String client_id;
+    private final KakaoService kakaoServiceImpl;
 
-    @Autowired
-    private KakaoService kakaoService;
+    @GetMapping("/login/kakao")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) throws IOException {
+        String accessToken = kakaoServiceImpl.getAccessTokenFromKakao(code);
+        KakaoLoginDto userInfo = kakaoServiceImpl.getUserInfo(accessToken);
+        return ResponseEntity.ok().body(userInfo); // User 데이터
+    }
 
+    /* TEST 인가 코드 받는 엔드 포인트 */
     @GetMapping("/sigin-callback")
-    public String callback(@RequestParam("code") String code) throws IOException {
-    	
-    	System.out.println("code ====="+code);
-        String accessToken = kakaoService.getAccessTokenFromKakao(client_id, code);
-        HashMap<String, Object> userInfo = kakaoService.getUserInfo(accessToken);
-        log.info("id : " + userInfo.get("id"));
-        // User 데이터
-        return userInfo.toString();
+    public String callback2(@RequestParam("code") String code) {
+        return code;
     }
-    
-    public String createAccessToken(long userId) {
-        Date now = new Date();
-        Date expiration = new Date(now.getTime() + Duration.ofHours(2).toMillis());
-        return Jwts.builder()
-                .claim("userId", userId)
-                .setIssuedAt(now)
-                .setExpiration(expiration)
-                .signWith(SignatureAlgorithm.HS256, /*Secrets.JWT_ACCESS_SECRET_KEY*/"??")
-                .compact();
-    }
-    
-    
-	/*
-	 * @Bean public OAuth2UserService<OAuth2UserRequest, OAuth2User>
-	 * oauth2UserService(OAuth2AuthorizedClientRepository clientRepository) {
-	 * DefaultOAuth2UserService delegate = new DefaultOAuth2UserService(); return
-	 * request -> { OAuth2User user = delegate.loadUser(request); // 커스텀 로직 추가
-	 * return user; }; }
-	 * 
-	 * @Bean public OAuth2AuthorizedClientRepository authorizedClientRepository() {
-	 * return new HttpSessionOAuth2AuthorizedClientRepository(); }
-	 */
 }

--- a/src/main/java/com/beside/archivist/dto/KakaoLoginDto.java
+++ b/src/main/java/com/beside/archivist/dto/KakaoLoginDto.java
@@ -1,0 +1,14 @@
+package com.beside.archivist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Builder
+@Getter
+public class KakaoLoginDto {
+
+    public String accessToken;
+    public String refreshToken;
+}

--- a/src/main/java/com/beside/archivist/dto/KakaoLoginDto.java
+++ b/src/main/java/com/beside/archivist/dto/KakaoLoginDto.java
@@ -3,12 +3,17 @@ package com.beside.archivist.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
-@AllArgsConstructor
-@Builder
 @Getter
 public class KakaoLoginDto {
 
-    public String accessToken;
-    public String refreshToken;
+    public String id;
+    public String nickname;
+
+    @Builder
+    public KakaoLoginDto(String id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/beside/archivist/service/KakaoService.java
+++ b/src/main/java/com/beside/archivist/service/KakaoService.java
@@ -12,7 +12,7 @@ import java.util.Map;
 @Service
 public interface KakaoService {
 	
-    String getAccessTokenFromKakao(String code) throws IOException;
+    String getAccessTokenFromKakao(String code);
 
-    KakaoLoginDto getUserInfo(String accessToken) throws IOException;
+    KakaoLoginDto getUserInfo(String accessToken);
 }

--- a/src/main/java/com/beside/archivist/service/KakaoService.java
+++ b/src/main/java/com/beside/archivist/service/KakaoService.java
@@ -1,17 +1,18 @@
 package com.beside.archivist.service;
 
+import com.beside.archivist.dto.KakaoLoginDto;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
-@Slf4j
 @Service
 public interface KakaoService {
 	
-    public String getAccessTokenFromKakao(String client_id, String code) throws IOException;
+    String getAccessTokenFromKakao(String code) throws IOException;
 
-    public HashMap<String, Object> getUserInfo(String access_Token) throws IOException;
+    KakaoLoginDto getUserInfo(String accessToken) throws IOException;
 }

--- a/src/main/java/com/beside/archivist/service/KakaoService.java
+++ b/src/main/java/com/beside/archivist/service/KakaoService.java
@@ -1,0 +1,17 @@
+package com.beside.archivist.service;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+@Slf4j
+@Service
+public interface KakaoService {
+	
+    public String getAccessTokenFromKakao(String client_id, String code) throws IOException;
+
+    public HashMap<String, Object> getUserInfo(String access_Token) throws IOException;
+}

--- a/src/main/java/com/beside/archivist/service/KakaoServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/KakaoServiceImpl.java
@@ -1,0 +1,114 @@
+package com.beside.archivist.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.beside.archivist.dto.KakaoLoginDto;
+import lombok.extern.slf4j.Slf4j;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class KakaoServiceImpl implements KakaoService{
+	
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+    public String getAccessTokenFromKakao(String client_id, String code) throws IOException {
+        //------kakao POST 요청------
+        String reqURL = "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="+client_id+"&code=" + code;
+        URL url = new URL(reqURL);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+        String line = "";
+        String result = "";
+
+        while ((line = br.readLine()) != null) {
+            result += line;
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {
+        });
+
+        log.info("Response Body : " + result);
+
+        String accessToken = (String) jsonMap.get("access_token");
+        String refreshToken = (String) jsonMap.get("refresh_token");
+        String scope = (String) jsonMap.get("scope");
+
+
+        log.info("Access Token : " + accessToken);
+        log.info("Refresh Token : " + refreshToken);
+        log.info("Scope : " + scope);
+
+
+        return accessToken;
+    }
+
+    public HashMap<String, Object> getUserInfo(String access_Token) throws IOException {
+        // 클라이언트 요청 정보
+        HashMap<String, Object> userInfo = new HashMap<String, Object>();
+
+
+        //------kakao GET 요청------
+        String reqURL = "https://kapi.kakao.com/v2/user/me";
+        URL url = new URL(reqURL);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Authorization", "Bearer " + access_Token);
+
+        int responseCode = conn.getResponseCode();
+        System.out.println("responseCode : " + responseCode);
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+
+        String line = "";
+        String result = "";
+
+        while ((line = br.readLine()) != null) {
+            result += line;
+        }
+
+        log.info("Response Body : " + result);
+
+        // jackson objectmapper 객체 생성
+        ObjectMapper objectMapper = new ObjectMapper();
+        // JSON String -> Map
+        Map<String, Object> jsonMap = objectMapper.readValue(result, new TypeReference<Map<String, Object>>() {
+        });
+
+
+        //사용자 정보 추출
+        Map<String, Object> properties = (Map<String, Object>) jsonMap.get("properties");
+        Map<String, Object> kakao_account = (Map<String, Object>) jsonMap.get("kakao_account");
+
+
+        Long id = (Long) jsonMap.get("id");
+        String nickname = properties.get("nickname").toString();
+        String profileImage = properties.get("profile_image").toString();
+        //String email = kakao_account.get("email").toString();
+
+        //userInfo에 넣기
+        userInfo.put("id", id);
+        userInfo.put("nickname", nickname);
+        userInfo.put("profileImage", profileImage);
+        //userInfo.put("email", email);
+
+
+        return userInfo;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 server.port=3000
-kakao.client_id=e23d78bdd0c94ce9fe632bcac07721d3
+kakao.client-id=e23d78bdd0c94ce9fe632bcac07721d3
 kakao.redirect_uri=http://localhost:3000/sigin-callback
+kakao.access-token-uri=https://kauth.kakao.com/oauth/token
+kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 google.client_id=439837364336-m9mbdgtm2fe7bs7hq1iii5mprq3voqr2.apps.googleusercontent.com
 google.redirect_uri=http://localhost:3000/auth/google/callback
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,26 @@
+server.port=3000
+kakao.client_id=e23d78bdd0c94ce9fe632bcac07721d3
+kakao.redirect_uri=http://localhost:3000/sigin-callback
+google.client_id=439837364336-m9mbdgtm2fe7bs7hq1iii5mprq3voqr2.apps.googleusercontent.com
+google.redirect_uri=http://localhost:3000/auth/google/callback
 
+
+spring.security.oauth2.client.registration.google.client-id=439837364336-m9mbdgtm2fe7bs7hq1iii5mprq3voqr2.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=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
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:3000/auth/google/callback
+spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/auth
+spring.security.oauth2.client.provider.google.token-uri=https://accounts.google.com/o/oauth2/token
+spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v3/userinfo
+spring.security.oauth2.client.provider.google.user-name-attribute=name
+
+spring.security.oauth2.client.registration.kakao.client-id=e23d78bdd0c94ce9fe632bcac07721d3
+spring.security.oauth2.client.registration.kakao.client-secret=IF2tbNBf3rS6WHKnSyBENdkXiBGhArFT
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:3000/sigin-callback
+spring.security.oauth2.client.registration.kakao.scope=	profile_nickname,profile_image,story_permalink
+spring.security.oauth2.client.registration.kakao.client-name=kakao
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id
+
+spring.security.oauth2.client.registration.kakao.authorizationGrantType=authorization_code


### PR DESCRIPTION
카카오 소셜로그인 베이스 구축 ( #5) 리팩토링

### 주요 변경 사항
- clientId, accesstokenuri 등 .properties 에서 값을 불러오도록 변경
- HttpURLConnection, BufferedReader 통신을 WebClient 로 변경
- obejctMapper.readValue 로 인한 연쇄적 IOException 제거를 위해 Gson 으로 변경