### PR TITLE
feat: 등록/수정자 추적을 위한 AuditorAware 설정 추가 (#37)

### DIFF
--- a/src/main/java/com/beside/archivist/ArchivistApplication.java
+++ b/src/main/java/com/beside/archivist/ArchivistApplication.java
@@ -2,10 +2,8 @@ package com.beside.archivist;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class ArchivistApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/beside/archivist/config/AuditConfig.java
+++ b/src/main/java/com/beside/archivist/config/AuditConfig.java
@@ -3,9 +3,11 @@ package com.beside.archivist.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @Configuration
+@EnableJpaAuditing
 public class AuditConfig {
     @Bean
     public AuditorAware<String> auditorProvider(){

--- a/src/main/java/com/beside/archivist/config/AuditConfig.java
+++ b/src/main/java/com/beside/archivist/config/AuditConfig.java
@@ -1,0 +1,14 @@
+package com.beside.archivist.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+
+@Configuration
+public class AuditConfig {
+    @Bean
+    public AuditorAware<String> auditorProvider(){
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/beside/archivist/config/AuditorAwareImpl.java
+++ b/src/main/java/com/beside/archivist/config/AuditorAwareImpl.java
@@ -1,0 +1,19 @@
+package com.beside.archivist.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) { // 인증이 안되어있다면
+            return Optional.empty();
+        }
+        return Optional.of(authentication.getName()); // 인증이 되었다면 회원 email return
+    }
+}


### PR DESCRIPTION
등록/수정자 추적을 위한 AuditorAware 설정 추가 (#37)

### 주요 변경 사항
-  AuditorAware 를 빈으로 등록하여 북마크 등을 등록/수정한 회원의 이메일 저장
- 인증이 필요없는 경우에는 등록/수정 회원 저장 X

### 고려 사항
- 회원 TB 에서는 등록/수정자를 저장할 필요가 없어서 분리에 대한 논의 필요.