### PR TITLE
feat: 중복 회원 검증 로직 추가 (#44)

### DIFF
--- a/src/main/java/com/beside/archivist/exception/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/ExceptionCode.java
@@ -3,13 +3,16 @@ package com.beside.archivist.exception;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.*;
 
+/** 예외 코드 관리 **/
 @Getter
 public enum ExceptionCode {
+    USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다.");
 
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+    private final HttpStatus status; // HTTP 상태 코드
+    private final String code; // 우리가 정의한 코드
+    private final String message; // 응답 메시지
 
     ExceptionCode(HttpStatus status, String code, String message) {
         this.status = status;

--- a/src/main/java/com/beside/archivist/exception/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/GlobalExceptionController.java
@@ -1,9 +1,21 @@
 package com.beside.archivist.exception;
 
+import com.beside.archivist.exception.users.UserAlreadyExistsException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/** 전역 예외 처리 **/
 @RestControllerAdvice
 public class GlobalExceptionController {
 
-
+    /** USER_001 중복 회원 체크 **/
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    protected ResponseEntity<ExceptionResponse> handlerUserNotFound(UserAlreadyExistsException ex) {
+        final ExceptionResponse responseError = ExceptionResponse.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
 }

--- a/src/main/java/com/beside/archivist/exception/users/UserAlreadyExistsException.java
+++ b/src/main/java/com/beside/archivist/exception/users/UserAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class UserAlreadyExistsException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/service/users/UserService.java
+++ b/src/main/java/com/beside/archivist/service/users/UserService.java
@@ -9,9 +9,14 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public interface UserService extends UserDetailsService {
+
+    /* 회원 CRUD */
     void adminLogin(String email, String password);
     UserInfoDto saveUser(UserDto userDto, UserImg userImg);
     UserInfoDto getUserInfo(String email);
     UserInfoDto updateUser(Long userId, UserDto userDto, MultipartFile userImgFile);
     void deleteUser(Long userId);
+
+    /* 회원 유효성 검증 */
+    void checkDuplicateUser(String email);
 }


### PR DESCRIPTION
유효성 검증 시 중복 회원 검증 로직 추가 (#44)

### 주요 변경 사항
- 예외 코드 ( ExceptionCode - code ) USER_xxx 포맷 사용
- 회원 가입 시 유니크 값이어야하는 이메일이 이미 사용되고 있을 때 예외 발생

### 고려 사항
- 지속적으로 업데이트 예정. 개선 사항이 있다면 말씀 부탁드립니다.