### PR TITLE
feat: 회원 연관관계 매핑 추가 (#50)

### DIFF
--- a/src/main/java/com/beside/archivist/entity/bookmark/Bookmark.java
+++ b/src/main/java/com/beside/archivist/entity/bookmark/Bookmark.java
@@ -20,7 +20,7 @@ public class Bookmark extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name="user_id", referencedColumnName = "user_id")
-    private User user;
+    private User users;
     @Column
     private String bookUrl;
     @Column
@@ -33,11 +33,11 @@ public class Bookmark extends BaseEntity {
     private BookmarkImg bookmarkImg;
 
     @Builder
-    public Bookmark(String bookUrl, String bookName, String bookDesc, User user,BookmarkImg bookmarkImg) {
+    public Bookmark(String bookUrl, String bookName, String bookDesc, User user, BookmarkImg bookmarkImg) {
         this.bookUrl = bookUrl;
         this.bookName = bookName;
         this.bookDesc = bookDesc;
-        this.user = user;
+        this.users = user;
         this.bookmarkImg = bookmarkImg;
     }
     public void update(BookmarkDto bookmarkDto) {

--- a/src/main/java/com/beside/archivist/entity/users/User.java
+++ b/src/main/java/com/beside/archivist/entity/users/User.java
@@ -4,12 +4,14 @@ package com.beside.archivist.entity.users;
 import com.beside.archivist.dto.users.UserDto;
 import com.beside.archivist.entity.BaseEntity;
 import com.beside.archivist.entity.BaseTimeEntity;
+import com.beside.archivist.entity.bookmark.Bookmark;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Table(name = "users") // user 예약어라 users로 명명
@@ -35,6 +37,9 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "user_img_id")
     private UserImg userImg;
 
+    @OneToMany(mappedBy = "users", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
     @Builder
     public User(String email, String password, String nickname, List<Category> categories, UserImg userImg) {
         this.email = email;
@@ -48,5 +53,9 @@ public class User extends BaseTimeEntity {
     public void updateUserInfo(String nickname, List<Category> categories) {
         this.nickname = nickname;
         this.categories = categories;
+    }
+
+    public void addBookmark(Bookmark b){
+        this.bookmarks.add(b);
     }
 }

--- a/src/main/java/com/beside/archivist/repository/bookmark/BookmarkRepository.java
+++ b/src/main/java/com/beside/archivist/repository/bookmark/BookmarkRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark,Long> {
 
-    List<Bookmark> findByUserId(Long userId);
+    List<Bookmark> findByUsers_Id(Long userId);
 }

--- a/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
@@ -3,7 +3,6 @@ package com.beside.archivist.service.bookmark;
 import com.beside.archivist.dto.bookmark.BookmarkDto;
 import com.beside.archivist.entity.bookmark.Bookmark;
 import com.beside.archivist.entity.bookmark.BookmarkImg;
-import com.beside.archivist.entity.users.User;
 
 import com.beside.archivist.repository.bookmark.BookmarkRepository;
 import jakarta.transaction.Transactional;
@@ -25,13 +24,13 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkImgServiceImpl bookmarkImgServiceImpl;
 
     @Override
-    public Bookmark saveBookmark(BookmarkDto bookmarkDto,User user)  {
+    public Bookmark saveBookmark(BookmarkDto bookmarkDto)  {
 
         Bookmark bookmark = Bookmark.builder()
                 .bookUrl(bookmarkDto.getBookUrl())
                 .bookName(bookmarkDto.getBookName())
                 .bookDesc(bookmarkDto.getBookDesc())
-                .user(user)
+                .user(bookmarkDto.getUser())
                 .build();
         bookmarkRepository.save(bookmark);
         return bookmark;

--- a/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
@@ -25,13 +25,13 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkImgServiceImpl bookmarkImgServiceImpl;
 
     @Override
-    public Bookmark saveBookmark(BookmarkDto bookmarkDto)  {
+    public Bookmark saveBookmark(BookmarkDto bookmarkDto,User user)  {
 
         Bookmark bookmark = Bookmark.builder()
                 .bookUrl(bookmarkDto.getBookUrl())
                 .bookName(bookmarkDto.getBookName())
                 .bookDesc(bookmarkDto.getBookDesc())
-                .user(bookmarkDto.getUser())
+                .user(user)
                 .build();
         bookmarkRepository.save(bookmark);
         return bookmark;
@@ -71,6 +71,6 @@ public class BookmarkServiceImpl implements BookmarkService {
 
     public List<Bookmark> getBookmarksByUserId(Long userId){
         // 특정 사용자 ID에 해당하는 북마크 목록 조회
-        return bookmarkRepository.findByUserId(userId);
+        return bookmarkRepository.findByUsers_Id(userId);
     }
 }


### PR DESCRIPTION
회원 연관관계 매핑 추가 (#50)

### 주요 변경 사항
- User 엔티티에 Bookmark와의 1:N 관계 설정
- BookmarkRepository 에서 외래키를 통해 조회하기위해 **findBy참조테이블_가져오고싶은필드** 로 인터페이스 재정의

### 고려 사항
- 순환 참조로 인해 응답값 변경 후 테스트 가능합니다.