### PR TITLE
refactor: 소셜 로그인 시 코드 리팩토링 및 예외 처리 개선 (#52)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
     @PostMapping("/login/kakao")
     public ResponseEntity<?> callback(@RequestParam("code") String code){
         String accessToken = kakaoServiceImpl.getAccessTokenFromKakao(code);
-        String response = kakaoServiceImpl.getUserInfo(accessToken);
+        KakaoLoginDto response = kakaoServiceImpl.getUserInfo(accessToken);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/com/beside/archivist/dto/users/KakaoLoginDto.java
+++ b/src/main/java/com/beside/archivist/dto/users/KakaoLoginDto.java
@@ -1,22 +1,17 @@
 package com.beside.archivist.dto.users;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
 @Getter
 public class KakaoLoginDto {
 
-    public String id;
-    public String nickname;
-    public String profileImage;
-    public String email;
+    public Long userId;
+    public String token;
 
     @Builder
-    public KakaoLoginDto(String nickname, String profileImage, String email) {
-        this.nickname = nickname;
-        this.profileImage = profileImage;
-        this.email = email;
+    public KakaoLoginDto(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
     }
 }

--- a/src/main/java/com/beside/archivist/exception/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/ExceptionCode.java
@@ -1,22 +1,18 @@
 package com.beside.archivist.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.*;
 
 /** 예외 코드 관리 **/
-@Getter
+@AllArgsConstructor @Getter
 public enum ExceptionCode {
-    USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다.");
+    USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
+    USER_NOT_FOUND(NOT_FOUND,"USER_02", "등록되지 않은 회원입니다.");
 
     private final HttpStatus status; // HTTP 상태 코드
     private final String code; // 우리가 정의한 코드
     private final String message; // 응답 메시지
-
-    ExceptionCode(HttpStatus status, String code, String message) {
-        this.status = status;
-        this.code = code;
-        this.message = message;
-    }
 }

--- a/src/main/java/com/beside/archivist/exception/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/GlobalExceptionController.java
@@ -1,6 +1,7 @@
 package com.beside.archivist.exception;
 
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
+import com.beside.archivist.exception.users.UserNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,10 +12,20 @@ public class GlobalExceptionController {
 
     /** USER_001 중복 회원 체크 **/
     @ExceptionHandler(UserAlreadyExistsException.class)
-    protected ResponseEntity<ExceptionResponse> handlerUserNotFound(UserAlreadyExistsException ex) {
+    protected ResponseEntity<ExceptionResponse> handlerUserAlreadyExistsException(UserAlreadyExistsException ex) {
         final ExceptionResponse responseError = ExceptionResponse.builder()
                 .statusCode(ex.getExceptionCode().getStatus().value())
                 .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** USER_002 기존 회원 유무 체크 **/
+    @ExceptionHandler(UserNotFoundException.class)
+    protected ResponseEntity<ExceptionResponse> handlerUserNotFoundException(UserNotFoundException ex) {
+        final ExceptionResponse responseError = ExceptionResponse.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getEmail())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }

--- a/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
+++ b/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
@@ -1,0 +1,11 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class UserNotFoundException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+    private final String email;
+}

--- a/src/main/java/com/beside/archivist/service/users/KakaoService.java
+++ b/src/main/java/com/beside/archivist/service/users/KakaoService.java
@@ -9,5 +9,5 @@ public interface KakaoService {
 	
     String getAccessTokenFromKakao(String code);
 
-    String getUserInfo(String accessToken);
+    KakaoLoginDto getUserInfo(String accessToken);
 }

--- a/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
@@ -2,6 +2,8 @@ package com.beside.archivist.service.users;
 
 import com.beside.archivist.dto.users.KakaoLoginDto;
 import com.beside.archivist.entity.users.User;
+import com.beside.archivist.exception.ExceptionCode;
+import com.beside.archivist.exception.users.UserNotFoundException;
 import com.beside.archivist.repository.users.UserRepository;
 import com.beside.archivist.utils.JwtTokenUtil;
 import com.google.gson.Gson;
@@ -17,6 +19,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service @Transactional
@@ -76,7 +79,8 @@ public class KakaoServiceImpl implements KakaoService{
         Map<String, Object> kakaoAccount = (Map<String, Object>) jsonMap.get("kakao_account");
         String userEmail = kakaoAccount.get("email").toString();
 
-        User findUser = userRepository.findByEmail(userEmail).orElseThrow();
+        // 등록된 유저가 없을 때 userEmail 반환
+        User findUser = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND, userEmail));
 
         return KakaoLoginDto.builder()
                 .userId(findUser.getId())


### PR DESCRIPTION
소셜 로그인 시 코드 리팩토링 및 예외 처리 개선 (#52)

### 주요 변경 사항
- KakaoLoginDto 에서 사용하지 않는 필드 제거 
- 소셜 로그인 성공 시 정의되지않은 response 값 -> KakaoLoginDto 로 변경
- 소셜 로그인 실패 시 ( 회원가입하지 않은 초기 유저 ) 예외 처리 로직 개선
