### PR TITLE
Category 값 재정의 및 조회 API 구현 (#67)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -4,6 +4,7 @@ package com.beside.archivist.controller.users;
 import com.beside.archivist.dto.users.KakaoLoginDto;
 import com.beside.archivist.dto.users.UserDto;
 import com.beside.archivist.dto.users.UserInfoDto;
+import com.beside.archivist.entity.users.Category;
 import com.beside.archivist.entity.users.UserImg;
 import com.beside.archivist.service.users.UserImgService;
 import com.beside.archivist.service.users.UserService;
@@ -74,5 +75,11 @@ public class UserController {
     public ResponseEntity<?> deleteUser(@PathVariable("userId") Long userId){
         userServiceImpl.deleteUser(userId);
         return ResponseEntity.ok().body("회원 탈퇴가 완료되었습니다.");
+    }
+
+    /** 카테고리 모든 값 조회 **/
+    @GetMapping("/categories")
+    public ResponseEntity<?> getCategories() {
+        return ResponseEntity.ok().body(Category.values());
     }
 }

--- a/src/main/java/com/beside/archivist/entity/users/Category.java
+++ b/src/main/java/com/beside/archivist/entity/users/Category.java
@@ -5,9 +5,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 public enum Category {
-    HOBBY("취미"), DEVELOPMENT("자기계발"), DRAWING("드로잉"), MUSIC("음악");
+    FOREIGN_LANGUAGES("외국어"), SELF_IMPROVEMENT("자기계발"),
+    CULTURAL_ACTIVITIES("문화생활"), PHOTOGRAPHY("사진"), EXERCISE("운동"),
+    FINANCIAL_MANAGEMENT("재태크"), HOBBIES("취미"), TRAVEL("여행"),
+    DRAWING("드로잉"), CAREER_DEVELOPMENT("커리어")
+    ;
 
-    @Getter
     private final String value;
 
     Category(String value) {

--- a/src/main/java/com/beside/archivist/entity/users/Category.java
+++ b/src/main/java/com/beside/archivist/entity/users/Category.java
@@ -5,10 +5,14 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 public enum Category {
-    FOREIGN_LANGUAGES("외국어"), SELF_IMPROVEMENT("자기계발"),
-    CULTURAL_ACTIVITIES("문화생활"), PHOTOGRAPHY("사진"), EXERCISE("운동"),
-    FINANCIAL_MANAGEMENT("재태크"), HOBBIES("취미"), TRAVEL("여행"),
-    DRAWING("드로잉"), CAREER_DEVELOPMENT("커리어")
+    LIFESTYLE("라이프스타일"), SELF_DEVELOPMENT("자기개발"),
+    CAREER("커리어"), HOBBY("취미"), EXERCISE("운동"),
+    MUSIC("음악"), ENTERTAINMENT("엔터테인먼트"),
+    FASHION("패션"), BEAUTY("뷰티"), TRAVEL("여행"),
+    RESTAURANTS("맛집"), KNOWLEDGE("지식"),
+    IT_TECHNOLOGY("IT/기술"), BUSINESS_ECONOMICS("비즈니스/경제"),
+    CULTURE("문화생활"), READING("독서"),
+    MOVIES("영화"), COOKING("요리");
     ;
 
     private final String value;


### PR DESCRIPTION
Category 값 재정의 및 조회 API 구현 (#67)

### 주요 변경 사항
-  Category 값 재정의 - 외국어, 자기계발, 문화생활, 사진, 운동, 재테크, 취미, 여행, 드로잉, 커리어
- 카테고리에 정의된 모든 값을 조회하는 API 추가

### 고려 사항
- 확정된 사항인지 재확인 필요
- FE 전달
