### PR TITLE
feat: 이미지 업로드 시 jpg/jpeg/png 외 확장자 예외 처리 추가 (#70)

### DIFF
--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -9,6 +9,7 @@ import static org.springframework.http.HttpStatus.*;
 /** 예외 코드 관리 **/
 @AllArgsConstructor @Getter
 public enum ExceptionCode {
+    INVALID_FILE_EXTENSION(BAD_REQUEST, "IMAGE_001", "잘못된 확장자입니다."),
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND,"USER_02", "등록되지 않은 회원입니다.");
 

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -2,6 +2,7 @@ package com.beside.archivist.exception.common;
 
 import com.beside.archivist.dto.exception.ExceptionDto;
 import com.beside.archivist.dto.exception.ValidExceptionDto;
+import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
 import com.beside.archivist.exception.users.UserNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -32,6 +33,17 @@ public class GlobalExceptionController {
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }
+
+    /** 이미지 확장자 체크 **/
+    @ExceptionHandler(InvalidFileExtensionException.class)
+    protected ResponseEntity<ExceptionDto> handlerInvalidFileExtensionException(InvalidFileExtensionException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
 
     /** USER_001 중복 회원 체크 **/
     @ExceptionHandler(UserAlreadyExistsException.class)

--- a/src/main/java/com/beside/archivist/exception/images/InvalidFileExtensionException.java
+++ b/src/main/java/com/beside/archivist/exception/images/InvalidFileExtensionException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.images;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class InvalidFileExtensionException extends RuntimeException {
+    private ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/service/util/FileService.java
+++ b/src/main/java/com/beside/archivist/service/util/FileService.java
@@ -1,5 +1,7 @@
 package com.beside.archivist.service.util;
 
+import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -38,7 +40,13 @@ public class FileService {
 
     private String extractExt(String originalFilename) { // 확장자 추출
         int pos = originalFilename.lastIndexOf(".");
-        return originalFilename.substring(pos + 1);
+        String ext = originalFilename.substring(pos + 1);
+
+        // jpg, jpeg, png 제외 확장자 예외 처리
+        if (!ext.equalsIgnoreCase("jpg") && !ext.equalsIgnoreCase("jpeg") && !ext.equalsIgnoreCase("png")){
+            throw new InvalidFileExtensionException(ExceptionCode.INVALID_FILE_EXTENSION);
+        }
+        return ext;
     }
 
     public void deleteFile(String imgLocation, String filePath){ // 파일 삭제


### PR DESCRIPTION
이미지 업로드 시 jpg/jpeg/png 외 확장자 예외 처리 추가 (#70)

### 주요 변경 사항
- jpg/jpeg/png 외 확장자 예외 처리 추가

### 고려 사항
- WebIA 문서 상 아래 이미지처럼 표기되어있어서 우선 크기 제한은 추가 안했습니다!
![image](https://github.com/team-archivist/archivist-backend/assets/79985588/609f909c-e11c-4d1c-a571-7ed39921f2b5)
