### PR TITLE
feat: 회원과 그룹간 Bookmark 테이블 작업 (#71)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -23,11 +23,11 @@ public class GroupController {
     private final GroupService groupServiceImpl;
 
     /** 특정 유저의 소유한 모든 그룹 조회 **/
-    @GetMapping("/user/group/{userId}")
-    public ResponseEntity<List<GroupDto>> getUserGroupList(@PathVariable("userId") Long userId) {
-        List<GroupDto> groups = groupServiceImpl.getGroupsByUserId(userId);
-        return ResponseEntity.ok().body(groups);
-    }
+//    @GetMapping("/user/group/{userId}")
+//    public ResponseEntity<List<GroupDto>> getUserGroupList(@PathVariable("userId") Long userId) {
+//        List<GroupDto> groups = groupServiceImpl.getGroupsByUserId(userId);
+//        return ResponseEntity.ok().body(groups);
+//    }
 
     /** 특정 그룹 상세 조회 **/
     @GetMapping("/group/{id}")

--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -2,6 +2,7 @@ package com.beside.archivist.controller.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.service.bookmark.BookmarkService;
 import com.beside.archivist.service.group.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -21,6 +22,7 @@ import java.util.List;
 public class GroupController {
 
     private final GroupService groupServiceImpl;
+    private final BookmarkService bookmarkServiceImpl;
 
     /** 특정 유저의 소유한 모든 그룹 조회 **/
 //    @GetMapping("/user/group/{userId}")
@@ -42,6 +44,7 @@ public class GroupController {
     public ResponseEntity<?> registerGroup(@RequestPart @Valid GroupDto groupDto,
                                               @RequestPart(value = "groupImgFile", required = false) MultipartFile groupImgFile) {
         GroupDto savedGroup = groupServiceImpl.saveGroup(groupDto,groupImgFile);
+        bookmarkServiceImpl.saveBookmark(savedGroup.getGroupId());
         return ResponseEntity.ok().body(savedGroup);
     }
 

--- a/src/main/java/com/beside/archivist/dto/group/GroupDto.java
+++ b/src/main/java/com/beside/archivist/dto/group/GroupDto.java
@@ -19,19 +19,17 @@ public class GroupDto {
     private String groupDesc;           //그룹 설명
     private Boolean isGroupPublic;      //그룹 공개 여부
     private List<Category> categories;  //그룹 카테고리
-    private Long userId;
     private String imgUrl;
     private Long linkCount;
 
     @Builder
-    public GroupDto(Long groupId, String groupName, String groupDesc, Boolean isGroupPublic, List<Category> categories, String imgUrl, Long userId,Long linkCount) {
+    public GroupDto(Long groupId, String groupName, String groupDesc, Boolean isGroupPublic, List<Category> categories, String imgUrl, Long linkCount) {
         this.groupId = groupId;
         this.groupName = groupName.trim();
         this.groupDesc = groupDesc;
         this.isGroupPublic = isGroupPublic;
         this.categories = categories;
         this.imgUrl = imgUrl;
-        this.userId = userId;
         this.linkCount = linkCount;
     }
 }

--- a/src/main/java/com/beside/archivist/entity/bookmark/Bookmark.java
+++ b/src/main/java/com/beside/archivist/entity/bookmark/Bookmark.java
@@ -1,0 +1,35 @@
+package com.beside.archivist.entity.bookmark;
+
+import com.beside.archivist.entity.group.Group;
+import com.beside.archivist.entity.users.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table @Entity @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark {
+    @Id
+    @Column(name = "bookmark_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private boolean isOwner;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User users;
+
+    @ManyToOne
+    @JoinColumn(name="group_id")
+    private Group groups;
+
+    @Builder
+    public Bookmark(boolean isOwner, User users, Group groups) {
+        this.isOwner = isOwner;
+        this.users = users;
+        this.groups = groups;
+    }
+}

--- a/src/main/java/com/beside/archivist/entity/group/Group.java
+++ b/src/main/java/com/beside/archivist/entity/group/Group.java
@@ -2,6 +2,7 @@ package com.beside.archivist.entity.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.entity.BaseEntity;
+import com.beside.archivist.entity.bookmark.Bookmark;
 import com.beside.archivist.entity.users.Category;
 import com.beside.archivist.entity.users.User;
 import jakarta.persistence.*;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Formula;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Table(name = "group_info")
@@ -34,10 +36,6 @@ public class Group extends BaseEntity {
     @Formula("(SELECT COUNT(lg.link_group_id) FROM link_group lg WHERE lg.group_id = group_id)")
     private Long linkCount;
 
-    @ManyToOne
-    @JoinColumn(name="user_id", referencedColumnName = "user_id")
-    private User users;
-
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_img_id")
     private GroupImg groupImg;
@@ -45,13 +43,15 @@ public class Group extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private List<LinkGroup> links;
 
+    @OneToMany(mappedBy = "groups", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
 
     @Builder
-    public Group(String groupName, String groupDesc, Boolean isGroupPublic, User user, List<Category> categories,GroupImg groupImg, Long linkCount, List<LinkGroup> links) {
+    public Group(String groupName, String groupDesc, Boolean isGroupPublic, List<Category> categories,GroupImg groupImg, Long linkCount, List<LinkGroup> links) {
         this.groupName = groupName;
         this.groupDesc = groupDesc;
         this.isGroupPublic = isGroupPublic;
-        this.users = user;
         this.categories = categories;
         this.groupImg = groupImg;
         this.linkCount = linkCount;
@@ -63,5 +63,9 @@ public class Group extends BaseEntity {
         this.isGroupPublic = groupDto.getIsGroupPublic();
         this.categories = groupDto.getCategories();
         this.linkCount = groupDto.getLinkCount();
+    }
+
+    public void addBookmark(Bookmark b) {
+        this.bookmarks.add(b);
     }
 }

--- a/src/main/java/com/beside/archivist/entity/users/User.java
+++ b/src/main/java/com/beside/archivist/entity/users/User.java
@@ -4,6 +4,7 @@ package com.beside.archivist.entity.users;
 import com.beside.archivist.dto.users.UserDto;
 import com.beside.archivist.entity.BaseEntity;
 import com.beside.archivist.entity.BaseTimeEntity;
+import com.beside.archivist.entity.bookmark.Bookmark;
 import com.beside.archivist.entity.link.Link;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -40,6 +41,9 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "users", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Link> links = new ArrayList<>();
 
+    @OneToMany(mappedBy = "users", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
     @Builder
     public User(String email, String password, String nickname, List<Category> categories, UserImg userImg) {
         this.email = email;
@@ -55,7 +59,10 @@ public class User extends BaseTimeEntity {
         this.categories = categories;
     }
 
-    public void addLink(Link b){
-        this.links.add(b);
+    public void addLink(Link l){
+        this.links.add(l);
+    }
+    public void addBookmark(Bookmark b) {
+        this.bookmarks.add(b);
     }
 }

--- a/src/main/java/com/beside/archivist/mapper/GroupMapper.java
+++ b/src/main/java/com/beside/archivist/mapper/GroupMapper.java
@@ -10,7 +10,6 @@ import org.mapstruct.ReportingPolicy;
 public interface GroupMapper {
 
     @Mapping(target = "groupId", source = "id")
-    @Mapping(target = "userId", source = "users.id")
     @Mapping(target = "imgUrl", source = "groupImg.imgUrl")
     GroupDto toDto(Group group);
     Group toEntity(GroupDto groupDto);

--- a/src/main/java/com/beside/archivist/repository/bookmark/BookmarkRepository.java
+++ b/src/main/java/com/beside/archivist/repository/bookmark/BookmarkRepository.java
@@ -1,0 +1,8 @@
+package com.beside.archivist.repository.bookmark;
+
+import com.beside.archivist.entity.bookmark.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/com/beside/archivist/repository/group/GroupRepository.java
+++ b/src/main/java/com/beside/archivist/repository/group/GroupRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 @Repository
 public interface GroupRepository extends JpaRepository<Group,Long> {
 
-    List<Group> findByUsers_Id(Long userId);
+//    List<Group> findByUsers_Id(Long userId);
 
     @Query("SELECT g FROM Group g LEFT JOIN FETCH g.links WHERE g.id = :groupId")
     Optional<Group> findByIdWithLinks(@Param("groupId") Long groupId);

--- a/src/main/java/com/beside/archivist/service/bookmark/BookmarkService.java
+++ b/src/main/java/com/beside/archivist/service/bookmark/BookmarkService.java
@@ -1,0 +1,9 @@
+package com.beside.archivist.service.bookmark;
+
+import com.beside.archivist.entity.bookmark.Bookmark;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface BookmarkService {
+    void saveBookmark(Long groupId);
+}

--- a/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/bookmark/BookmarkServiceImpl.java
@@ -1,0 +1,34 @@
+package com.beside.archivist.service.bookmark;
+
+import com.beside.archivist.config.AuditConfig;
+import com.beside.archivist.entity.bookmark.Bookmark;
+import com.beside.archivist.repository.bookmark.BookmarkRepository;
+import com.beside.archivist.service.group.GroupService;
+import com.beside.archivist.service.users.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service @Transactional
+@RequiredArgsConstructor
+public class BookmarkServiceImpl implements BookmarkService{
+    private final BookmarkRepository bookmarkRepository;
+    private final UserService userServiceImpl;
+    private final GroupService groupServiceImpl;
+    private final AuditConfig auditConfig;
+    @Override
+    public void saveBookmark(Long groupId) {
+        String userEmail = auditConfig.auditorProvider().getCurrentAuditor()
+                .orElseThrow(RuntimeException::new); // todo: 인증 X, 예외 처리
+
+        Bookmark bookmark = Bookmark.builder()
+                .isOwner(true) // 내가 생성한 그룹
+                .users(userServiceImpl.getUserByEmail(userEmail))
+                .groups(groupServiceImpl.getGroup(groupId))
+                .build();
+
+        bookmark.getUsers().addBookmark(bookmark);
+        bookmark.getGroups().addBookmark(bookmark);
+        bookmarkRepository.save(bookmark);
+    }
+}

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -10,15 +10,14 @@ import java.util.List;
 
 @Service
 public interface GroupService {
+
+    /** GROUP CRUD **/
     GroupDto saveGroup(GroupDto groupDto, MultipartFile groupImgFile);
-
+    GroupDto findGroupById(Long groupId);
     GroupDto updateGroup(Long groupId, GroupDto groupDto, MultipartFile groupImgFile);
-
+    Group getGroup(Long groupId);
     void deleteGroup(Long groupId);
 
-    GroupDto findGroupById(Long groupId);
-
 //    List<GroupDto> getGroupsByUserId(Long userId);
-
     List<LinkDto> getLinksByGroupId(Long groupId);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -2,6 +2,7 @@ package com.beside.archivist.service.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.entity.group.Group;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,7 +18,7 @@ public interface GroupService {
 
     GroupDto findGroupById(Long groupId);
 
-    List<GroupDto> getGroupsByUserId(Long userId);
+//    List<GroupDto> getGroupsByUserId(Long userId);
 
     List<LinkDto> getLinksByGroupId(Long groupId);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -26,7 +26,7 @@ public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
 
-    private final GroupImgService groupImgService;
+    private final GroupImgService groupImgServiceImpl;
     private final GroupMapper groupMapperImpl;
 
     private final AuditConfig auditConfig;
@@ -42,9 +42,9 @@ public class GroupServiceImpl implements GroupService {
 
         GroupImg groupImg;
         if(groupImgFile == null){
-            groupImg = groupImgService.initializeDefaultImg();
+            groupImg = groupImgServiceImpl.initializeDefaultImg();
         }else{
-            groupImg = groupImgService.insertGroupImg(groupImgFile);
+            groupImg = groupImgServiceImpl.insertGroupImg(groupImgFile);
         }
 
         Group group = Group.builder()
@@ -52,11 +52,11 @@ public class GroupServiceImpl implements GroupService {
                 .groupDesc(groupDto.getGroupDesc())
                 .isGroupPublic(groupDto.getIsGroupPublic())
                 .categories(groupDto.getCategories())
-                .user(user)
                 .groupImg(groupImg)
                 .linkCount(0L)
                 .build();
         groupRepository.save(group);
+
         return groupMapperImpl.toDto(group);
     }
 
@@ -66,9 +66,9 @@ public class GroupServiceImpl implements GroupService {
 
         if(groupImgFile != null){
             if(group.getGroupImg() == null){
-                groupImgService.insertGroupImg(groupImgFile);
+                groupImgServiceImpl.insertGroupImg(groupImgFile);
             }else{
-                groupImgService.updateGroupImg(group.getGroupImg().getId(), groupImgFile);
+                groupImgServiceImpl.updateGroupImg(group.getGroupImg().getId(), groupImgFile);
             }
         }
 
@@ -93,14 +93,14 @@ public class GroupServiceImpl implements GroupService {
         return groupMapperImpl.toDto(group);
     }
 
-    public List<GroupDto> getGroupsByUserId(Long userId){
-        // 특정 사용자 ID에 해당하는 북마크 목록 조회
-        List<Group> groupList = groupRepository.findByUsers_Id(userId);
-
-        return groupList.stream()
-                .map(groupMapperImpl::toDto)
-                .collect(Collectors.toList());
-    }
+//    public List<GroupDto> getGroupsByUserId(Long userId){
+//        // 특정 사용자 ID에 해당하는 북마크 목록 조회
+//        List<Group> groupList = groupRepository.findByUsers_Id(userId);
+//
+//        return groupList.stream()
+//                .map(groupMapperImpl::toDto)
+//                .collect(Collectors.toList());
+//    }
 
 
     public  List<LinkDto> getLinksByGroupId(Long groupId){

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -5,7 +5,6 @@ import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.GroupImg;
-import com.beside.archivist.entity.users.User;
 import com.beside.archivist.mapper.GroupMapper;
 import com.beside.archivist.repository.group.GroupRepository;
 import com.beside.archivist.repository.users.UserRepository;
@@ -25,21 +24,11 @@ import java.util.stream.Collectors;
 public class GroupServiceImpl implements GroupService {
 
     private final GroupRepository groupRepository;
-
     private final GroupImgService groupImgServiceImpl;
     private final GroupMapper groupMapperImpl;
 
-    private final AuditConfig auditConfig;
-
-    private final UserRepository userRepository;
-
-
     @Override
     public GroupDto saveGroup(GroupDto groupDto, MultipartFile groupImgFile)  {
-        Optional<String> authentication = auditConfig.auditorProvider().getCurrentAuditor();
-        String email = authentication.get();
-        User user = userRepository.findByEmail(email).orElseThrow();
-
         GroupImg groupImg;
         if(groupImgFile == null){
             groupImg = groupImgServiceImpl.initializeDefaultImg();
@@ -79,6 +68,11 @@ public class GroupServiceImpl implements GroupService {
                 .categories(groupDto.getCategories())
                 .build());
         return groupMapperImpl.toDto(group);
+    }
+
+    @Override
+    public Group getGroup(Long groupId) {
+        return groupRepository.findById(groupId).orElseThrow(RuntimeException::new);
     }
 
     @Override

--- a/src/main/java/com/beside/archivist/service/users/UserService.java
+++ b/src/main/java/com/beside/archivist/service/users/UserService.java
@@ -2,6 +2,7 @@ package com.beside.archivist.service.users;
 
 import com.beside.archivist.dto.users.UserDto;
 import com.beside.archivist.dto.users.UserInfoDto;
+import com.beside.archivist.entity.users.User;
 import com.beside.archivist.entity.users.UserImg;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public interface UserService extends UserDetailsService {
     UserInfoDto saveUser(UserDto userDto, UserImg userImg);
     UserInfoDto getUserInfo(String email);
     UserInfoDto updateUser(Long userId, UserDto userDto, MultipartFile userImgFile);
+    User getUserByEmail(String email);
     void deleteUser(Long userId);
 
     /* 회원 유효성 검증 */

--- a/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
@@ -67,14 +67,18 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserInfoDto getUserInfo(String email) {
-        User findUser = userRepository.findByEmail(email).orElseThrow();
-
+        User findUser = getUserByEmail(email);
         return userMapperImpl.toDto(findUser);
     }
 
     @Override
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(RuntimeException::new); // todo: 예외 처리
+    }
+
+    @Override
     public UserInfoDto updateUser(Long userId, UserDto userDto,MultipartFile userImgFile) {
-        User user = userRepository.findById(userId).orElseThrow(RuntimeException::new); // 추후 예외 커스텀
+        User user = userRepository.findById(userId).orElseThrow(RuntimeException::new); // todo: 예외 처리
         user.updateUserInfo(userDto.getNickname(),userDto.getCategories()); // 유저 정보 update
         userImgServiceImpl.updateUserImg(user.getUserImg().getId(), userImgFile); // 유저 이미지 update
 


### PR DESCRIPTION
회원과 그룹간 Bookmark 테이블 작업 (#71)

### 주요 변경 사항
- 회원-그룹 N:N 관계 해소를 위한 Bookmark 테이블 추가
- 그룹은 회원을 바로 보고있지 않으므로 user 필드 모두 사용 중지 ( 주석 처리 )
- 그룹 생성 API 에서 그룹 데이터에 회원 데이터를 저장하는 대신 Bookmark 에서 그룹 및 회원 데이터 저장

### 고려 사항
- 코드 리뷰 이후 userId 제거 및 관련 API 처리 ( ex> 특정 유저의 그룹 조회하기 ) 
- 다른 사람의 그룹을 북마크하는 API 구현해야 함. ( isOwner 필드가 false ) 