### PR TITLE
feat: 회원 가입 API 토큰 인증 적용 (#80)

### DIFF
--- a/src/main/java/com/beside/archivist/dto/exception/LoginFailureDto.java
+++ b/src/main/java/com/beside/archivist/dto/exception/LoginFailureDto.java
@@ -1,0 +1,17 @@
+package com.beside.archivist.dto.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginFailureDto{
+    private final int statusCode;
+    private final String email;
+    private final String token;
+    @Builder
+    public LoginFailureDto(int statusCode, String email, String token) {
+        this.statusCode = statusCode;
+        this.email = email;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -12,7 +12,8 @@ public enum ExceptionCode {
     INVALID_FILE_EXTENSION(BAD_REQUEST, "IMAGE_001", "잘못된 확장자입니다."),
     MAX_SIZE_EXCEEDED(EXPECTATION_FAILED, "IMAGE_002", "10MB 이하의 파일로 올려주세요."),
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
-    USER_NOT_FOUND(NOT_FOUND,"USER_02", "등록되지 않은 회원입니다.");
+    USER_NOT_FOUND(NOT_FOUND,"USER_02", "등록되지 않은 회원입니다."),
+    EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_03", "회원과 토큰의 정보가 맞지 않습니다.");
 
     private final HttpStatus status; // HTTP 상태 코드
     private final String code; // 우리가 정의한 코드

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -1,6 +1,7 @@
 package com.beside.archivist.exception.common;
 
 import com.beside.archivist.dto.exception.ExceptionDto;
+import com.beside.archivist.dto.exception.LoginFailureDto;
 import com.beside.archivist.dto.exception.ValidExceptionDto;
 import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
@@ -68,10 +69,11 @@ public class GlobalExceptionController {
 
     /** USER_002 기존 회원 유무 체크 **/
     @ExceptionHandler(UserNotFoundException.class)
-    protected ResponseEntity<ExceptionDto> handlerUserNotFoundException(UserNotFoundException ex) {
-        final ExceptionDto responseError = ExceptionDto.builder()
+    protected ResponseEntity<LoginFailureDto> handlerUserNotFoundException(UserNotFoundException ex) {
+        final LoginFailureDto responseError = LoginFailureDto.builder()
                 .statusCode(ex.getExceptionCode().getStatus().value())
-                .message(ex.getEmail())
+                .email(ex.getEmail())
+                .token(ex.getToken())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -4,9 +4,13 @@ import com.beside.archivist.dto.exception.ExceptionDto;
 import com.beside.archivist.dto.exception.LoginFailureDto;
 import com.beside.archivist.dto.exception.ValidExceptionDto;
 import com.beside.archivist.exception.images.InvalidFileExtensionException;
+import com.beside.archivist.exception.users.EmailTokenMismatchException;
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
 import com.beside.archivist.exception.users.UserNotFoundException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -74,6 +78,16 @@ public class GlobalExceptionController {
                 .statusCode(ex.getExceptionCode().getStatus().value())
                 .email(ex.getEmail())
                 .token(ex.getToken())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** USER_003 토큰에서 추출한 이메일과 요청받은 이메일이 맞지 않은 경우 **/
+    @ExceptionHandler(EmailTokenMismatchException.class)
+    protected ResponseEntity<ExceptionDto> handlerEmailTokenMismatchException(EmailTokenMismatchException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }

--- a/src/main/java/com/beside/archivist/exception/users/EmailTokenMismatchException.java
+++ b/src/main/java/com/beside/archivist/exception/users/EmailTokenMismatchException.java
@@ -1,0 +1,11 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class EmailTokenMismatchException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
+++ b/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class UserNotFoundException extends RuntimeException{
     private final ExceptionCode exceptionCode;
     private final String email;
+    private final String token;
 }

--- a/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
@@ -77,13 +77,14 @@ public class KakaoServiceImpl implements KakaoService{
         // 사용자 정보 추출
         Map<String, Object> kakaoAccount = (Map<String, Object>) jsonMap.get("kakao_account");
         String userEmail = kakaoAccount.get("email").toString();
+        String token = jwtTokenUtil.generateToken(userEmail);
 
-        // 등록된 유저가 없을 때 userEmail 반환
-        User findUser = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND, userEmail));
+        // 등록된 유저가 없을 때 userEmail 반환 + JWT
+        User findUser = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND, userEmail, token));
 
         return KakaoLoginDto.builder()
                 .userId(findUser.getId())
-                .token(jwtTokenUtil.generateToken(userEmail))
+                .token(token)
                 .build();
     }
 }


### PR DESCRIPTION
회원 가입 API 토큰 인증 적용 (#80)

### 주요 변경 사항
- 로그인 실패 시 응답 값 변경 : 로그인 실패 시에 token 값 추가로 인해 DTO 재정의 ( LoginFailureDto 추가 )
- 회원가입 API 토큰 인증 적용 : JWTfiler 를 먼저 거쳐서 토큰 인증을 하게 되면 Response 값의 email 값을 재사용할 수 없기 때문에 Controller 단에서 받아서 처리
- token 에서 추출한 email 과 응답받은 email 정보가 다를 때 예외 처리 추가 구현 ( EmailTokenMismatchException )