### PR TITLE
feat: 로그인 API 응답 시 헤더에 Token 추가 (#82)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -38,7 +38,12 @@ public class UserController {
     public ResponseEntity<?> callback(@RequestParam("code") String code){
         String accessToken = kakaoServiceImpl.getAccessTokenFromKakao(code);
         KakaoLoginDto response = kakaoServiceImpl.getUserInfo(accessToken);
-        return ResponseEntity.ok().body(response);
+
+        // 쿠키에 토큰 정보 추가- FE 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Set-Cookie", "Token=" + response.getToken() + "; HttpOnly; Path=/; Max-Age=3600");
+
+        return ResponseEntity.ok().headers(headers).body(response);
     }
 
     /** 관리자용 엔드 포인트 구현 **/

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -79,7 +79,12 @@ public class GlobalExceptionController {
                 .email(ex.getEmail())
                 .token(ex.getToken())
                 .build();
-        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+
+        // 쿠키에 토큰 정보 추가- FE 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Set-Cookie", "Token=" + ex.getToken() + "; HttpOnly; Path=/; Max-Age=3600");
+
+        return ResponseEntity.status(responseError.getStatusCode()).headers(headers).body(responseError);
     }
 
     /** USER_003 토큰에서 추출한 이메일과 요청받은 이메일이 맞지 않은 경우 **/


### PR DESCRIPTION
로그인 API 응답 시 헤더에 Token 추가 (#82)

### 주요 변경 사항
- 로그인 성공 시 쿠키에 토큰 정보 추가
- 로그인 실패 예외 발생 시에도 쿠키에 토큰 정보 추가

### 고려 사항
- body 에서 header로 변경이 된 게 아니라 둘 다 응답 -> FE 요청
- header 에서 토큰 탈취에 대한 보안 이슈 고려