### PR TITLE
feature : NCP 스토리지로 이미지 저장소 변경  (#72)

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -6,10 +6,10 @@ kakao.access-token-uri=https://kauth.kakao.com/oauth/token
 kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 
 # 이미지 경로 설정
-userImgLocation = /home/images/users
-linkImgLocation = /home/images/links
-groupImgLocation = /home/images/groups
-uploadPath = file:///home/images/
+userImgLocation = /mnt/xvdb1/images/users
+linkImgLocation = /mnt/xvdb1/images/links
+groupImgLocation = /mnt/xvdb1/images/groups
+uploadPath = file:///mnt/xvdb1/images/
 defaultImgPath = classpath:/static/default-image/
 
 # 이미지 크기 제한


### PR DESCRIPTION
NCP 스토리지로 이미지 저장소 변경

### 주요 변경 사항

- 블록 스토리지 xen(하이퍼바이저), ssd(스토리지 종류)로 생성
- /mnt/xvdb1 에 /dev/xvdb1 와 마운트
- 이미지 저장 경로 /mnt/xvdb1로 변경

### 고려사항
- 블록 스토리지 용량
- 운영 테스트 필요