### PR TITLE
feat: 닉네임 조회 API 구현 (#86)

### DIFF
--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig{
                                 .requestMatchers("/api/admin").permitAll()
                                 .requestMatchers("/login/**").permitAll()
                                 .requestMatchers("/user").permitAll()
-                                .requestMatchers("/categories").permitAll()
+                                .requestMatchers("/categories", "/nicknames").permitAll()
                                 .requestMatchers("/swagger-ui/**","/v3/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/**").permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.*;
 import com.beside.archivist.service.users.KakaoService;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @Slf4j
@@ -98,4 +100,12 @@ public class UserController {
     public ResponseEntity<?> getCategories() {
         return ResponseEntity.ok().body(Category.values());
     }
+
+    /** 정의되어있는 모든 닉네임 조회 **/
+    @GetMapping("/nicknames")
+    public ResponseEntity<?> getNicknames() {
+        List<String> nicknames = userServiceImpl.getNicknames();
+        return ResponseEntity.ok().body(nicknames);
+    }
+
 }

--- a/src/main/java/com/beside/archivist/service/users/UserService.java
+++ b/src/main/java/com/beside/archivist/service/users/UserService.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Service
 public interface UserService extends UserDetailsService {
 
@@ -21,4 +23,5 @@ public interface UserService extends UserDetailsService {
 
     /* 회원 유효성 검증 */
     void checkDuplicateUser(String email);
+    List<String> getNicknames();
 }

--- a/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
@@ -96,4 +96,8 @@ public class UserServiceImpl implements UserService {
             throw new UserAlreadyExistsException(ExceptionCode.USER_ALREADY_EXISTS);
         });
     }
+    @Override
+    public List<String> getNicknames() {
+        return userRepository.findAll().stream().map(User::getNickname).toList();
+    }
 }


### PR DESCRIPTION
닉네임 조회 API 구현 (#86)

### 주요 변경 사항
- 회원 DB에 저장되어있는 모든 닉네임을 조회하는 API 추가
- 해당 API 토큰 인증 해제

### 고려 사항
- FE 전달