### PR TITLE
refactor: UserNotFound 분리 및 재정의 (#88)

### DIFF
--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -13,7 +13,8 @@ public enum ExceptionCode {
     MAX_SIZE_EXCEEDED(EXPECTATION_FAILED, "IMAGE_002", "10MB 이하의 파일로 올려주세요."),
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
     SIGN_UP_REQUIRED(NOT_FOUND,"USER_002", "등록되지 않은 이메일입니다. 회원가입을 진행해주세요."),
-    EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_003", "회원과 토큰의 정보가 맞지 않습니다."),
+    USER_NOT_FOUND(NOT_FOUND,"USER_003","사용자 정보가 존재하지 않습니다."),
+    EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다.")
     ;
     

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -12,7 +12,7 @@ public enum ExceptionCode {
     INVALID_FILE_EXTENSION(BAD_REQUEST, "IMAGE_001", "잘못된 확장자입니다."),
     MAX_SIZE_EXCEEDED(EXPECTATION_FAILED, "IMAGE_002", "10MB 이하의 파일로 올려주세요."),
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
-    USER_NOT_FOUND(NOT_FOUND,"USER_002", "등록되지 않은 회원입니다."),
+    SIGN_UP_REQUIRED(NOT_FOUND,"USER_002", "등록되지 않은 이메일입니다. 회원가입을 진행해주세요."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_003", "회원과 토큰의 정보가 맞지 않습니다."),
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다.")
     ;

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -4,10 +4,7 @@ import com.beside.archivist.dto.exception.ExceptionDto;
 import com.beside.archivist.dto.exception.LoginFailureDto;
 import com.beside.archivist.dto.exception.ValidExceptionDto;
 import com.beside.archivist.exception.images.InvalidFileExtensionException;
-import com.beside.archivist.exception.users.EmailTokenMismatchException;
-import com.beside.archivist.exception.users.InvalidCategoryNameException;
-import com.beside.archivist.exception.users.UserAlreadyExistsException;
-import com.beside.archivist.exception.users.SignUpRequiredException;
+import com.beside.archivist.exception.users.*;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -70,7 +67,7 @@ public class GlobalExceptionController {
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }
 
-    /** USER_002 기존 회원 유무 체크 **/
+    /** USER_002 회원 가입 유무 체크 **/
     @ExceptionHandler(SignUpRequiredException.class)
     protected ResponseEntity<LoginFailureDto> handlerSignUpRequiredException(SignUpRequiredException ex) {
         final LoginFailureDto responseError = LoginFailureDto.builder()
@@ -86,7 +83,17 @@ public class GlobalExceptionController {
         return ResponseEntity.status(responseError.getStatusCode()).headers(headers).body(responseError);
     }
 
-    /** USER_003 토큰에서 추출한 이메일과 요청받은 이메일이 맞지 않은 경우 **/
+    /** USER_003 회원 유무 체크 **/
+    @ExceptionHandler(UserNotFoundException.class)
+    protected ResponseEntity<ExceptionDto> handlerUserNotFoundException(UserNotFoundException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** USER_004 토큰에서 추출한 이메일과 요청받은 이메일이 맞지 않은 경우 **/
     @ExceptionHandler(EmailTokenMismatchException.class)
     protected ResponseEntity<ExceptionDto> handlerEmailTokenMismatchException(EmailTokenMismatchException ex) {
         final ExceptionDto responseError = ExceptionDto.builder()

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -7,9 +7,7 @@ import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import com.beside.archivist.exception.users.EmailTokenMismatchException;
 import com.beside.archivist.exception.users.InvalidCategoryNameException;
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
-import com.beside.archivist.exception.users.UserNotFoundException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
+import com.beside.archivist.exception.users.SignUpRequiredException;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -73,8 +71,8 @@ public class GlobalExceptionController {
     }
 
     /** USER_002 기존 회원 유무 체크 **/
-    @ExceptionHandler(UserNotFoundException.class)
-    protected ResponseEntity<LoginFailureDto> handlerUserNotFoundException(UserNotFoundException ex) {
+    @ExceptionHandler(SignUpRequiredException.class)
+    protected ResponseEntity<LoginFailureDto> handlerSignUpRequiredException(SignUpRequiredException ex) {
         final LoginFailureDto responseError = LoginFailureDto.builder()
                 .statusCode(ex.getExceptionCode().getStatus().value())
                 .email(ex.getEmail())

--- a/src/main/java/com/beside/archivist/exception/users/SignUpRequiredException.java
+++ b/src/main/java/com/beside/archivist/exception/users/SignUpRequiredException.java
@@ -1,0 +1,12 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class SignUpRequiredException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+    private final String email;
+    private final String token;
+}

--- a/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
+++ b/src/main/java/com/beside/archivist/exception/users/UserNotFoundException.java
@@ -4,9 +4,7 @@ import com.beside.archivist.exception.common.ExceptionCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-@AllArgsConstructor @Getter
+@Getter @AllArgsConstructor
 public class UserNotFoundException extends RuntimeException{
     private final ExceptionCode exceptionCode;
-    private final String email;
-    private final String token;
 }

--- a/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/KakaoServiceImpl.java
@@ -3,7 +3,7 @@ package com.beside.archivist.service.users;
 import com.beside.archivist.dto.users.KakaoLoginDto;
 import com.beside.archivist.entity.users.User;
 import com.beside.archivist.exception.common.ExceptionCode;
-import com.beside.archivist.exception.users.UserNotFoundException;
+import com.beside.archivist.exception.users.SignUpRequiredException;
 import com.beside.archivist.repository.users.UserRepository;
 import com.beside.archivist.utils.JwtTokenUtil;
 import com.google.gson.Gson;
@@ -80,7 +80,7 @@ public class KakaoServiceImpl implements KakaoService{
         String token = jwtTokenUtil.generateToken(userEmail);
 
         // 등록된 유저가 없을 때 userEmail 반환 + JWT
-        User findUser = userRepository.findByEmail(userEmail).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND, userEmail, token));
+        User findUser = userRepository.findByEmail(userEmail).orElseThrow(() -> new SignUpRequiredException(ExceptionCode.SIGN_UP_REQUIRED, userEmail, token));
 
         return KakaoLoginDto.builder()
                 .userId(findUser.getId())


### PR DESCRIPTION
UserNotFound 분리 및 재정의 (#88)

### 주요 변경 사항
- 회원가입을 해야하는 초기 유저가 로그인 하였을 때와 그 외에 회원 데이터가 DB에 없을 때 예외를 분리
- SignUpRequiredException 정의
- UserNotFound 적용