### PR TITLE
feat: API 요청 시 필수 값에 대한 검증 및 예외 처리 (#89)

### DIFF
--- a/src/main/java/com/beside/archivist/dto/users/UserDto.java
+++ b/src/main/java/com/beside/archivist/dto/users/UserDto.java
@@ -1,10 +1,7 @@
 package com.beside.archivist.dto.users;
 
 import com.beside.archivist.entity.users.Category;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -14,11 +11,14 @@ import java.util.List;
 public class UserDto {
 
     @Pattern(regexp = "^[A-Za-z0-9_\\.\\-]+@[A-Za-z0-9\\-]+\\.[A-Za-z0-9\\-]+$", message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수 값입니다.")
     private String email;
 
     @Size(min = 2, message = "닉네임은 2자 이상 입력해주세요") @Size(max = 20, message = "닉네임은 20자 이하로 입력해주세요")
     @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$",message = "닉네임은 띄어쓰기 없이 한글, 영문, 숫자만 가능해요" )
+    @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;
 
+    @NotEmpty(message = "카테고리는 필수 값입니다.")
     private List<Category> categories;
 }

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -14,9 +14,9 @@ public enum ExceptionCode {
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND,"USER_002", "등록되지 않은 회원입니다."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_003", "회원과 토큰의 정보가 맞지 않습니다."),
-    INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다.")
+    INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
+    REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다.")
     ;
-    
 
     private final HttpStatus status; // HTTP 상태 코드
     private final String code; // 우리가 정의한 코드

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -8,8 +8,6 @@ import com.beside.archivist.exception.users.EmailTokenMismatchException;
 import com.beside.archivist.exception.users.InvalidCategoryNameException;
 import com.beside.archivist.exception.users.UserAlreadyExistsException;
 import com.beside.archivist.exception.users.UserNotFoundException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -18,6 +16,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -104,6 +103,16 @@ public class GlobalExceptionController {
         final ExceptionDto responseError = ExceptionDto.builder()
                 .statusCode(ex.getExceptionCode().getStatus().value())
                 .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** VALID_001 필수 값 체크 **/
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    protected ResponseEntity<ExceptionDto> handlerRequestPartMissingException() {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ExceptionCode.REQUEST_PART_MISSING.getStatus().value())
+                .message(ExceptionCode.REQUEST_PART_MISSING.getMessage())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }


### PR DESCRIPTION
API 요청 시 필수 값에 대한 검증 및 예외 처리 (#89)

### 주요 변경 사항
- API 요청 시 userDto, linkDto 등 필수 값 누락에 대한 예외 처리 ( ErrorCode: VALID_001 )
- UserDto 필드 검증을 위한 @NotBlank 및 @NotEmpty 어노테이션 추가

### 고려 사항
- 예외 처리는 전역적으로 적용되나 null 값에 대한 예외처리는 다른 DTO 에도 적용이 되어야 할 것 같습니다!
