### PR TITLE
refactor: 회원이 생성한 그룹 조회 API 변경 (#100)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -2,6 +2,7 @@ package com.beside.archivist.controller.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.entity.usergroup.UserGroup;
 import com.beside.archivist.service.usergroup.UserGroupService;
 import com.beside.archivist.service.group.GroupService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,12 +25,13 @@ public class GroupController {
     private final GroupService groupServiceImpl;
     private final UserGroupService userGroupServiceImpl;
 
-    /** 특정 유저의 소유한 모든 그룹 조회 **/
-//    @GetMapping("/user/group/{userId}")
-//    public ResponseEntity<List<GroupDto>> getUserGroupList(@PathVariable("userId") Long userId) {
-//        List<GroupDto> groups = groupServiceImpl.getGroupsByUserId(userId);
-//        return ResponseEntity.ok().body(groups);
-//    }
+    /** 특정 유저가 생성한 모든 그룹 조회 **/
+    @GetMapping("/user/group/{userId}")
+    public ResponseEntity<List<GroupDto>> getUserGroupList(@PathVariable("userId") Long userId) {
+        List<UserGroup> userGroups = userGroupServiceImpl.getUserGroupsByUserId(userId);
+        List<GroupDto> groups = groupServiceImpl.getGroupsByUserGroup(userGroups);
+        return ResponseEntity.ok().body(groups);
+    }
 
     /** 특정 그룹 상세 조회 **/
     @GetMapping("/group/{id}")

--- a/src/main/java/com/beside/archivist/repository/usergroup/UserGroupRepository.java
+++ b/src/main/java/com/beside/archivist/repository/usergroup/UserGroupRepository.java
@@ -3,6 +3,10 @@ package com.beside.archivist.repository.usergroup;
 import com.beside.archivist.entity.usergroup.UserGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
 @Repository
 public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
+    List<UserGroup> findByUsers_Id(Long userId);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -3,6 +3,7 @@ package com.beside.archivist.service.group;
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
+import com.beside.archivist.entity.usergroup.UserGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,7 +18,6 @@ public interface GroupService {
     GroupDto updateGroup(Long groupId, GroupDto groupDto, MultipartFile groupImgFile);
     Group getGroup(Long groupId);
     void deleteGroup(Long groupId);
-
-//    List<GroupDto> getGroupsByUserId(Long userId);
+    List<GroupDto> getGroupsByUserGroup(List<UserGroup> userGroups);
     List<LinkDto> getLinksByGroupId(Long groupId);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -1,13 +1,12 @@
 package com.beside.archivist.service.group;
 
-import com.beside.archivist.config.AuditConfig;
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.GroupImg;
+import com.beside.archivist.entity.usergroup.UserGroup;
 import com.beside.archivist.mapper.GroupMapper;
 import com.beside.archivist.repository.group.GroupRepository;
-import com.beside.archivist.repository.users.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,7 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 
 @Service
@@ -82,19 +80,20 @@ public class GroupServiceImpl implements GroupService {
 
     public GroupDto findGroupById(Long id){
         // 특정 북마크 ID에 해당하는 북마크 조회
-        Group group = groupRepository.findById(id).orElseThrow();
-
+        Group group = groupRepository.findById(id).orElseThrow(); // todo: 예외처리
         return groupMapperImpl.toDto(group);
     }
 
-//    public List<GroupDto> getGroupsByUserId(Long userId){
-//        // 특정 사용자 ID에 해당하는 북마크 목록 조회
-//        List<Group> groupList = groupRepository.findByUsers_Id(userId);
-//
-//        return groupList.stream()
-//                .map(groupMapperImpl::toDto)
-//                .collect(Collectors.toList());
-//    }
+    @Override
+    public List<GroupDto> getGroupsByUserGroup(List<UserGroup> userGroups){
+        List<Group> groupList = userGroups.stream()
+                .map(UserGroup::getGroups)
+                .toList();
+
+        return groupList.stream()
+                .map(groupMapperImpl::toDto)
+                .toList();
+    }
 
 
     public  List<LinkDto> getLinksByGroupId(Long groupId){

--- a/src/main/java/com/beside/archivist/service/usergroup/UserGroupService.java
+++ b/src/main/java/com/beside/archivist/service/usergroup/UserGroupService.java
@@ -1,8 +1,13 @@
 package com.beside.archivist.service.usergroup;
 
+import com.beside.archivist.entity.usergroup.UserGroup;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public interface UserGroupService {
     void saveUserGroup(Long groupId);
+
+    List<UserGroup> getUserGroupsByUserId(Long userId);
 }

--- a/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
@@ -1,6 +1,7 @@
 package com.beside.archivist.service.usergroup;
 
 import com.beside.archivist.config.AuditConfig;
+import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.usergroup.UserGroup;
 import com.beside.archivist.repository.usergroup.UserGroupRepository;
 import com.beside.archivist.service.group.GroupService;
@@ -8,6 +9,8 @@ import com.beside.archivist.service.users.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service @Transactional
 @RequiredArgsConstructor
@@ -30,5 +33,12 @@ public class UserGroupServiceImpl implements UserGroupService {
         userGroup.getUsers().addUserGroup(userGroup);
         userGroup.getGroups().addUserGroup(userGroup);
         userGroupRepository.save(userGroup);
+    }
+
+    @Override
+    public List<UserGroup> getUserGroupsByUserId(Long userId) {
+        return userGroupRepository.findByUsers_Id(userId).stream()
+                .filter(UserGroup::isOwner) // 본인이 생성한 그룹만 조회
+                .toList();
     }
 }


### PR DESCRIPTION
회원이 생성한 그룹 조회 API 변경 (#100)

### 주요 변경 사항
- 회원-그룹 간 UserGroup 테이블을 중간 테이블로 재설계했기때문에 회원의 그룹 조회 API 변경
- 회원 본인이 생성한 그룹들 모두 조회 ( 북마크 X -> isOwner 가 true ) 

### 고려 사항
- 그룹 북마크하는 API 생성 후 북마크한 그룹들 조회하는 API 따로 구현 예정