### PR TITLE
feat: 카카오 인가 코드 만료에 대한 예외 처리 추가 (#103)

### DIFF
--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -11,12 +11,15 @@ import static org.springframework.http.HttpStatus.*;
 public enum ExceptionCode {
     INVALID_FILE_EXTENSION(BAD_REQUEST, "IMAGE_001", "잘못된 확장자입니다."),
     MAX_SIZE_EXCEEDED(EXPECTATION_FAILED, "IMAGE_002", "10MB 이하의 파일로 올려주세요."),
+
     USER_ALREADY_EXISTS(CONFLICT, "USER_001", "이미 등록된 회원입니다."),
     SIGN_UP_REQUIRED(NOT_FOUND,"USER_002", "등록되지 않은 이메일입니다. 회원가입을 진행해주세요."),
     USER_NOT_FOUND(NOT_FOUND,"USER_003","사용자 정보가 존재하지 않습니다."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
+    AUTHORIZATION_CODE_EXPIRED(BAD_REQUEST, "USER_005", "인가 코드가 만료되었습니다. 재발급 받아주세요."),
+
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
-    REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다.")
+    REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다."),
     ;
 
     private final HttpStatus status; // HTTP 상태 코드

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -123,4 +124,15 @@ public class GlobalExceptionController {
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }
+
+    /** USER_005 카카오 인가코드가 만료되거나 잘못되었을 경우 체크 **/
+    @ExceptionHandler(WebClientResponseException.class)
+    protected ResponseEntity<ExceptionDto> handlerWebClientResponseException() {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ExceptionCode.AUTHORIZATION_CODE_EXPIRED.getStatus().value())
+                .message(ExceptionCode.AUTHORIZATION_CODE_EXPIRED.getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
 }


### PR DESCRIPTION
카카오 인가 코드 만료에 대한 예외 처리 추가 (#103)

### 주요 변경 사항
- 카카오 인가 코드가 만료된 경우 500 으로 응답되어 예외 처리 추가 ( USER_005 )

### 고려 사항
- API 접근 제어 설정( 1/13 업데이트 예정 )하기 전까지는 401 로 반환됩니다. 