### PR TITLE
feat: 링크 및 그룹 데이터 없을 때 예외 처리 (#102) 

### DIFF
--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -17,8 +17,8 @@ public enum ExceptionCode {
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
     REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다."),
-    LINK_NOT_FOUND(BAD_REQUEST,"LINK_001","링크 정보가 존재하지 않습니다."),
-    GROUP_NOT_FOUND(BAD_REQUEST,"GROUP_001","그룹 정보가 존재하지 않습니다.")
+    LINK_NOT_FOUND(NOT_FOUND,"LINK_001","링크 정보가 존재하지 않습니다."),
+    GROUP_NOT_FOUND(NOT_FOUND,"GROUP_001","그룹 정보가 존재하지 않습니다.")
     ;
 
     private final HttpStatus status; // HTTP 상태 코드

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -16,7 +16,9 @@ public enum ExceptionCode {
     USER_NOT_FOUND(NOT_FOUND,"USER_003","사용자 정보가 존재하지 않습니다."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
-    REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다.")
+    REQUEST_PART_MISSING(BAD_REQUEST,"VALID_001","필수 값이 누락되었습니다."),
+    LINK_NOT_FOUND(BAD_REQUEST,"LINK_001","링크 정보가 존재하지 않습니다."),
+    GROUP_NOT_FOUND(BAD_REQUEST,"GROUP_001","그룹 정보가 존재하지 않습니다.")
     ;
 
     private final HttpStatus status; // HTTP 상태 코드

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -3,7 +3,9 @@ package com.beside.archivist.exception.common;
 import com.beside.archivist.dto.exception.ExceptionDto;
 import com.beside.archivist.dto.exception.LoginFailureDto;
 import com.beside.archivist.dto.exception.ValidExceptionDto;
+import com.beside.archivist.exception.group.GroupNotFoundException;
 import com.beside.archivist.exception.images.InvalidFileExtensionException;
+import com.beside.archivist.exception.link.LinkNotFoundException;
 import com.beside.archivist.exception.users.*;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
@@ -120,6 +122,26 @@ public class GlobalExceptionController {
         final ExceptionDto responseError = ExceptionDto.builder()
                 .statusCode(ExceptionCode.REQUEST_PART_MISSING.getStatus().value())
                 .message(ExceptionCode.REQUEST_PART_MISSING.getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** LINK_001 링크 유무 체크 **/
+    @ExceptionHandler(LinkNotFoundException.class)
+    protected ResponseEntity<ExceptionDto> handlerLinkNotFoundException(LinkNotFoundException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** GROUP_001 그룹 유무 체크 **/
+    @ExceptionHandler(GroupNotFoundException.class)
+    protected ResponseEntity<ExceptionDto> handlerGroupNotFoundException(GroupNotFoundException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }

--- a/src/main/java/com/beside/archivist/exception/group/GroupNotFoundException.java
+++ b/src/main/java/com/beside/archivist/exception/group/GroupNotFoundException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.group;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor
+public class GroupNotFoundException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/exception/link/LinkNotFoundException.java
+++ b/src/main/java/com/beside/archivist/exception/link/LinkNotFoundException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.link;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor
+public class LinkNotFoundException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -5,6 +5,8 @@ import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.GroupImg;
 import com.beside.archivist.entity.usergroup.UserGroup;
+import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.group.GroupNotFoundException;
 import com.beside.archivist.mapper.GroupMapper;
 import com.beside.archivist.repository.group.GroupRepository;
 import jakarta.transaction.Transactional;
@@ -49,7 +51,7 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     public GroupDto updateGroup(Long groupId, GroupDto groupDto, MultipartFile groupImgFile) {
-        Group group = groupRepository.findById(groupId).orElseThrow(RuntimeException::new);
+        Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
 
         if(groupImgFile != null){
             if(group.getGroupImg() == null){
@@ -70,7 +72,7 @@ public class GroupServiceImpl implements GroupService {
 
     @Override
     public Group getGroup(Long groupId) {
-        return groupRepository.findById(groupId).orElseThrow(RuntimeException::new);
+        return groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
     }
 
     @Override
@@ -80,7 +82,7 @@ public class GroupServiceImpl implements GroupService {
 
     public GroupDto findGroupById(Long id){
         // 특정 북마크 ID에 해당하는 북마크 조회
-        Group group = groupRepository.findById(id).orElseThrow(); // todo: 예외처리
+        Group group = groupRepository.findById(id).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND)); // todo: 예외처리
         return groupMapperImpl.toDto(group);
     }
 
@@ -99,7 +101,8 @@ public class GroupServiceImpl implements GroupService {
     public  List<LinkDto> getLinksByGroupId(Long groupId){
         Optional<Group> groupList = groupRepository.findByIdWithLinks(groupId);
 
-        return groupList.orElseThrow().getLinks().stream()
+        return groupList.orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND))
+                .getLinks().stream()
                 .map(m-> new LinkDto(m.getLink().getId(),
                         m.getLink().getLinkUrl(),
                         m.getLink().getLinkName(),

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
@@ -5,6 +5,9 @@ import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.LinkGroup;
 import com.beside.archivist.entity.link.Link;
 
+import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.group.GroupNotFoundException;
+import com.beside.archivist.exception.link.LinkNotFoundException;
 import com.beside.archivist.mapper.LinkGroupMapper;
 import com.beside.archivist.repository.group.GroupRepository;
 import com.beside.archivist.repository.group.LinkGroupRepository;
@@ -36,8 +39,8 @@ public class LinkGroupServiceImpl implements LinkGroupService {
         Optional<Group> group = groupRepository.findById(linkGroupDto.getGroupId());
 
         LinkGroup linkGroup = LinkGroup.builder()
-                .link(link.orElseThrow())
-                .group(group.orElseThrow())
+                .link(link.orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND)))
+                .group(group.orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND)))
                 .build();
         linkGroupRepository.save(linkGroup);
         return linkGroupMapperImpl.toDto(linkGroup);

--- a/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
@@ -9,6 +9,8 @@ import com.beside.archivist.entity.users.User;
 
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.images.InvalidFileExtensionException;
+import com.beside.archivist.exception.link.LinkNotFoundException;
+import com.beside.archivist.exception.users.UserNotFoundException;
 import com.beside.archivist.mapper.LinkMapper;
 import com.beside.archivist.repository.link.LinkRepository;
 import com.beside.archivist.repository.users.UserRepository;
@@ -41,7 +43,7 @@ public class LinkServiceImpl implements LinkService {
     public LinkDto saveLink(LinkDto linkDto, MultipartFile linkImgFile)  {
         Optional<String> authentication = auditConfig.auditorProvider().getCurrentAuditor();
         String email = authentication.get();
-        User user = userRepository.findByEmail(email).orElseThrow();
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND));
 
         LinkImg linkImg = null;
         if(linkImgFile == null || extractExtCheck(linkImgFile)){
@@ -73,7 +75,7 @@ public class LinkServiceImpl implements LinkService {
 
     @Override
     public LinkDto updateLink(Long linkId, LinkDto linkDto, MultipartFile linkImgFile) {
-        Link link = linkRepository.findById(linkId).orElseThrow(RuntimeException::new);
+        Link link = linkRepository.findById(linkId).orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND));
         if(linkImgFile != null){
             if(extractExtCheck(linkImgFile)){
                 throw new InvalidFileExtensionException(ExceptionCode.INVALID_FILE_EXTENSION);
@@ -96,7 +98,7 @@ public class LinkServiceImpl implements LinkService {
 
     public LinkDto findLinkById(Long id){
         // 특정 북마크 ID에 해당하는 북마크 조회
-        Link link = linkRepository.findById(id).orElseThrow();
+        Link link = linkRepository.findById(id).orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND));
 
         return linkMapperImpl.toDto(link);
     }

--- a/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
@@ -8,7 +8,6 @@ import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.entity.users.User;
 
 import com.beside.archivist.exception.common.ExceptionCode;
-import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import com.beside.archivist.exception.link.LinkNotFoundException;
 import com.beside.archivist.exception.users.UserNotFoundException;
 import com.beside.archivist.mapper.LinkMapper;
@@ -46,7 +45,7 @@ public class LinkServiceImpl implements LinkService {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND));
 
         LinkImg linkImg = null;
-        if(linkImgFile == null || extractExtCheck(linkImgFile)){
+        if(linkImgFile == null){
             linkImg = linkImgService.initializeDefaultImg();
         }else{
             linkImg = linkImgService.insertLinkImg(linkImgFile);
@@ -64,22 +63,10 @@ public class LinkServiceImpl implements LinkService {
         return linkMapperImpl.toDto(link);
     }
 
-    private boolean extractExtCheck(MultipartFile imgFile) { // 확장자 추출
-        String originalFilename = imgFile.getOriginalFilename();
-        int pos = originalFilename.lastIndexOf(".");
-        String ext = originalFilename.substring(pos + 1);
-
-        // jpg, jpeg, png 제외 확장자 예외 처리
-        return !ext.equalsIgnoreCase("jpg") && !ext.equalsIgnoreCase("jpeg") && !ext.equalsIgnoreCase("png");
-    }
-
     @Override
     public LinkDto updateLink(Long linkId, LinkDto linkDto, MultipartFile linkImgFile) {
         Link link = linkRepository.findById(linkId).orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND));
         if(linkImgFile != null){
-            if(extractExtCheck(linkImgFile)){
-                throw new InvalidFileExtensionException(ExceptionCode.INVALID_FILE_EXTENSION);
-            }
             if(link.getLinkImg() == null){
                 linkImgService.insertLinkImg(linkImgFile);
             }else{

--- a/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/users/UserServiceImpl.java
@@ -31,7 +31,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email).orElseThrow();
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND));
         return new org.springframework.security.core.userdetails.User(
                 user.getEmail(), user.getPassword(),
                 true, true, true, true,


### PR DESCRIPTION
삭제한 링크 및 그룹 데이터 없을 때 예외 처리

### 주요 변경 사항

- LinkNotFoundException 정의
- GroupNotFoundException 정의

### 고려 사항
- 토큰인증 시 유저정보가 없을 경우 예외처리 추가(?)
- linkGroup 중복 등록 예외처리 추가