### PR TITLE
fix: API 접근 제어 설정 (#104)

### DIFF
--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -46,13 +47,13 @@ public class SecurityConfig{
         http
                 .authorizeHttpRequests(
                         request -> request
-                                .requestMatchers("/api/admin").permitAll()
-                                .requestMatchers("/login/**").permitAll()
-                                .requestMatchers("/user").permitAll()
-                                .requestMatchers("/categories", "/nicknames").permitAll()
-                                .requestMatchers("/swagger-ui/**","/v3/api-docs/**").permitAll()
-                                .requestMatchers("/actuator/**").permitAll()
-                                .anyRequest().authenticated()
+                                .requestMatchers("/user").permitAll() // Controller 에서 인증
+                                .requestMatchers("/user/**").authenticated()
+                                .requestMatchers(HttpMethod.GET, "/link/{linkId}").permitAll()
+                                .requestMatchers("/link","/link/{linkId}").authenticated()
+                                .requestMatchers(HttpMethod.GET, "/group/{groupId}").permitAll()
+                                .requestMatchers("/group","/group/{groupId}").authenticated()
+                                .anyRequest().permitAll()
                 )
                 .csrf().disable()
                 .cors().configurationSource(corsConfigurationSource())// cors 설정

--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -27,6 +27,7 @@ public class GroupController {
 
     /** 특정 유저가 생성한 모든 그룹 조회 **/
     @GetMapping("/user/group/{userId}")
+    @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<List<GroupDto>> getUserGroupList(@PathVariable("userId") Long userId) {
         List<UserGroup> userGroups = userGroupServiceImpl.getUserGroupsByUserId(userId);
         List<GroupDto> groups = groupServiceImpl.getGroupsByUserGroup(userGroups);

--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -35,8 +35,8 @@ public class GroupController {
     }
 
     /** 특정 그룹 상세 조회 **/
-    @GetMapping("/group/{id}")
-    public ResponseEntity<?> findGroupById(@PathVariable("id") Long id) {
+    @GetMapping("/group/{groupId}")
+    public ResponseEntity<?> findGroupById(@PathVariable("groupId") Long id) {
         GroupDto group = groupServiceImpl.findGroupById(id);
         return ResponseEntity.ok().body(group);
     }
@@ -70,8 +70,8 @@ public class GroupController {
     }
 
     /** 특정 그룹에 속한 링크들 모두 조회 **/
-    @GetMapping("/group/link/{id}")
-    public ResponseEntity<?> getLinksByGroupId(@PathVariable("id") Long id) {
+    @GetMapping("/group/link/{groupId}")
+    public ResponseEntity<?> getLinksByGroupId(@PathVariable("groupId") Long id) {
         List<LinkDto> group = groupServiceImpl.getLinksByGroupId(id);
         return ResponseEntity.ok().body(group);
     }

--- a/src/main/java/com/beside/archivist/controller/link/LinkController.java
+++ b/src/main/java/com/beside/archivist/controller/link/LinkController.java
@@ -23,8 +23,9 @@ public class LinkController {
 
     private final LinkService linkServiceImpl;
 
-    /** 회원이 북마크/저장한 링크 모두 조회 **/
+    /** 회원이 저장한 링크 모두 조회 **/
     @GetMapping("/user/link/{userId}")
+    @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<List<LinkDto>> getUserLinkList(@PathVariable("userId") Long userId) {
         List<LinkDto> links = linkServiceImpl.getLinksByUserId(userId);
         return ResponseEntity.ok().body(links);

--- a/src/main/java/com/beside/archivist/controller/link/LinkController.java
+++ b/src/main/java/com/beside/archivist/controller/link/LinkController.java
@@ -32,8 +32,8 @@ public class LinkController {
     }
 
     /** 특정 링크 상세 조회 **/
-    @GetMapping("/link/{id}")
-    public ResponseEntity<?> findLinkById(@PathVariable("id") Long id) {
+    @GetMapping("/link/{linkId}")
+    public ResponseEntity<?> findLinkById(@PathVariable("linkId") Long id) {
         LinkDto link = linkServiceImpl.findLinkById(id);
         return ResponseEntity.ok().body(link);
     }


### PR DESCRIPTION
API 접근 제어 설정 (#104)

### 주요 변경 사항
- 기존에 토큰 인증 API 에 대한 정리가 안되어있어 SecurityConfig 에 재정의
- anyRequest().authenricated() -> anyRequest().permitAll() 로 변경 ( 이거 때문에 500으로 안떨어지고 401 로 떨어짐 )
- LinkController 및 GroupController 에서 id 로 표기되어있는 경로 변수명 변경

### 고려 사항
- 현재 구현되지 않은 API 에 대한 토큰 인증여부 정의 필요