### PR TITLE
chore: Hibernate DDL 자동 설정 update로 변경 (#111)

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -22,7 +22,7 @@ spring.config.activate.on-profile=prod
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql=trace
-spring.jpa.hibernate.ddl-auto = create
+spring.jpa.hibernate.ddl-auto = update
 
 # DB 설정
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
Hibernate DDL 자동 설정 update로 변경 (#111)

### 주요 변경 사항
- 운영 환경에서 Hibernate DDL 설정을 create -> update 로 변경

### 고려 사항
- 잦은 push 로 인해 기존 데이터 손실 방지를 위해 변경하나 새로운 필드/테이블 추가 시에 null 값 체크 필요.