### PR TITLE
feat: 그룹 썸네일 예외 처리 (#78)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/group/LinkGroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/LinkGroupController.java
@@ -20,14 +20,16 @@ public class LinkGroupController {
 
     private final LinkGroupService linkGroupServiceImpl;
 
+    /** 그룹에 링크 저장 **/
     @PostMapping("/group/link")
     @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<?> registerLinkGroup(@RequestPart @Valid LinkGroupDto linkGroupDto) {
         LinkGroupDto savedLinkGroup = linkGroupServiceImpl.saveLinkGroup(linkGroupDto);
+        linkGroupServiceImpl.changeGroupImg(linkGroupDto.getGroupId()); // 그룹 이미지 변경
         return ResponseEntity.status(HttpStatus.CREATED).body(savedLinkGroup);
     }
     
-
+    /** 그룹에서 링크 제거하기 **/
     @DeleteMapping("/group/link/{linkGroupId}")
     @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<?> deleteLinkGroup(@PathVariable("linkGroupId") Long linkGroupId){

--- a/src/main/java/com/beside/archivist/entity/group/GroupImg.java
+++ b/src/main/java/com/beside/archivist/entity/group/GroupImg.java
@@ -33,4 +33,11 @@ public class GroupImg {
         this.oriImgName = oriImgName;
         this.imgUrl = imgUrl;
     }
+    public static GroupImg initializeDefaultLinkImg() {
+        return GroupImg.builder()
+                .imgName("linkDefaultImg")
+                .oriImgName("linkDefaultImg.png")
+                .imgUrl("/image/linkDefaultImg.png")
+                .build();
+    }
 }

--- a/src/main/java/com/beside/archivist/entity/link/LinkImg.java
+++ b/src/main/java/com/beside/archivist/entity/link/LinkImg.java
@@ -33,4 +33,11 @@ public class LinkImg {
         this.oriImgName = oriImgName;
         this.imgUrl = imgUrl;
     }
+    public static LinkImg initializeDefaultLinkImg() {
+        return LinkImg.builder()
+                .imgName("linkDefaultImg")
+                .oriImgName("linkDefaultImg.png")
+                .imgUrl("/image/linkDefaultImg.png")
+                .build();
+    }
 }

--- a/src/main/java/com/beside/archivist/repository/group/GroupRepository.java
+++ b/src/main/java/com/beside/archivist/repository/group/GroupRepository.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 @Repository
 public interface GroupRepository extends JpaRepository<Group,Long> {
 
-//    List<Group> findByUsers_Id(Long userId);
-
     @Query("SELECT g FROM Group g LEFT JOIN FETCH g.links WHERE g.id = :groupId")
     Optional<Group> findByIdWithLinks(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/beside/archivist/repository/group/LinkGroupRepository.java
+++ b/src/main/java/com/beside/archivist/repository/group/LinkGroupRepository.java
@@ -5,6 +5,9 @@ import com.beside.archivist.entity.group.LinkGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LinkGroupRepository extends JpaRepository<LinkGroup,Long> {
+    List<LinkGroup> findByGroup_Id(Long groupId);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgService.java
@@ -1,14 +1,15 @@
 package com.beside.archivist.service.group;
 
 import com.beside.archivist.entity.group.GroupImg;
+import com.beside.archivist.entity.link.LinkImg;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 public interface GroupImgService {
 
-    GroupImg initializeDefaultImg();
+    GroupImg initializeDefaultLinkImg();
+    void initializeLinkImg(GroupImg groupImg, LinkImg linkImg);
     GroupImg insertGroupImg(MultipartFile groupImgFile);
-
     void updateGroupImg(Long groupImgId, MultipartFile groupImgFile);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgService.java
@@ -9,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface GroupImgService {
 
     GroupImg initializeDefaultLinkImg();
-    void initializeLinkImg(GroupImg groupImg, LinkImg linkImg);
+    void changeToLinkImg(GroupImg groupImg, LinkImg linkImg);
     GroupImg insertGroupImg(MultipartFile groupImgFile);
     void updateGroupImg(Long groupImgId, MultipartFile groupImgFile);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
@@ -3,7 +3,6 @@ package com.beside.archivist.service.group;
 import com.beside.archivist.entity.group.GroupImg;
 import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.repository.group.GroupImgRepository;
-import com.beside.archivist.service.group.GroupImgService;
 import com.beside.archivist.service.util.FileService;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
@@ -23,14 +22,10 @@ public class GroupImgServiceImpl implements GroupImgService {
 
     @Override
     public GroupImg initializeDefaultLinkImg() {
-        return groupImgRepository.save(GroupImg.builder()
-                .oriImgName("linkDefaultImg.png")
-                .imgName("linkDefaultImg")
-                .imgUrl("/image/linkDefaultImg.png")
-                .build());
+        return groupImgRepository.save(GroupImg.initializeDefaultLinkImg());
     }
     @Override
-    public void initializeLinkImg(GroupImg groupImg, LinkImg linkImg) {
+    public void changeToLinkImg(GroupImg groupImg, LinkImg linkImg) {
         groupImg.updateGroupImg(linkImg.getImgName(), linkImg.getOriImgName(), linkImg.getImgUrl());
     }
 

--- a/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
@@ -1,6 +1,7 @@
 package com.beside.archivist.service.group;
 
 import com.beside.archivist.entity.group.GroupImg;
+import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.repository.group.GroupImgRepository;
 import com.beside.archivist.service.group.GroupImgService;
 import com.beside.archivist.service.util.FileService;
@@ -21,14 +22,19 @@ public class GroupImgServiceImpl implements GroupImgService {
     private final FileService fileService;
 
     @Override
-    public GroupImg initializeDefaultImg() {
+    public GroupImg initializeDefaultLinkImg() {
         return groupImgRepository.save(GroupImg.builder()
-                .oriImgName("groupDefaultImg.png")
-                .imgName("groupDefaultImg")
-                .imgUrl("/image/groupDefaultImg.png")
+                .oriImgName("linkDefaultImg.png")
+                .imgName("linkDefaultImg")
+                .imgUrl("/image/linkDefaultImg.png")
                 .build());
     }
+    @Override
+    public void initializeLinkImg(GroupImg groupImg, LinkImg linkImg) {
+        groupImg.updateGroupImg(linkImg.getImgName(), linkImg.getOriImgName(), linkImg.getImgUrl());
+    }
 
+    @Override
     public GroupImg insertGroupImg(MultipartFile groupImgFile) {
         if(groupImgFile != null){
 

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -3,6 +3,7 @@ package com.beside.archivist.service.group;
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
+import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.entity.usergroup.UserGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,4 +21,6 @@ public interface GroupService {
     void deleteGroup(Long groupId);
     List<GroupDto> getGroupsByUserGroup(List<UserGroup> userGroups);
     List<LinkDto> getLinksByGroupId(Long groupId);
+
+    void changeToLinkImg(Long groupId, LinkImg linkImg);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -31,7 +31,7 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public GroupDto saveGroup(GroupDto groupDto, MultipartFile groupImgFile)  {
         GroupImg groupImg;
-        if(groupImgFile == null){
+        if(groupImgFile == null){ // 그룹 이미지를 넣지 않았을 때 링크 디폴트 이미지로 설정
             groupImg = groupImgServiceImpl.initializeDefaultLinkImg();
         }else{
             groupImg = groupImgServiceImpl.insertGroupImg(groupImgFile);
@@ -50,12 +50,13 @@ public class GroupServiceImpl implements GroupService {
         return groupMapperImpl.toDto(group);
     }
 
+    /** 그룹 썸네일을 파라미터로 전달받은 linkImg 로 변경 **/
     @Override
     public void changeToLinkImg(Long groupId, LinkImg linkImg) { // 해당 링크 이미지 삭제했을 떄 다른 이미지로 바꾸는 등의 작업 필요
         GroupImg groupImg = groupRepository.findById(groupId)
                 .orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND))
                 .getGroupImg();
-        groupImgServiceImpl.initializeLinkImg(groupImg,linkImg);
+        groupImgServiceImpl.changeToLinkImg(groupImg,linkImg); // groupImg -> linkImg 로 변경
     }
 
     @Override
@@ -92,7 +93,7 @@ public class GroupServiceImpl implements GroupService {
     @Override
     public GroupDto findGroupById(Long id){
         // 특정 북마크 ID에 해당하는 북마크 조회
-        Group group = groupRepository.findById(id).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND)); // todo: 예외처리
+        Group group = groupRepository.findById(id).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
         return groupMapperImpl.toDto(group);
     }
 

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -4,6 +4,7 @@ import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.GroupImg;
+import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.entity.usergroup.UserGroup;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.group.GroupNotFoundException;
@@ -31,7 +32,7 @@ public class GroupServiceImpl implements GroupService {
     public GroupDto saveGroup(GroupDto groupDto, MultipartFile groupImgFile)  {
         GroupImg groupImg;
         if(groupImgFile == null){
-            groupImg = groupImgServiceImpl.initializeDefaultImg();
+            groupImg = groupImgServiceImpl.initializeDefaultLinkImg();
         }else{
             groupImg = groupImgServiceImpl.insertGroupImg(groupImgFile);
         }
@@ -47,6 +48,14 @@ public class GroupServiceImpl implements GroupService {
         groupRepository.save(group);
 
         return groupMapperImpl.toDto(group);
+    }
+
+    @Override
+    public void changeToLinkImg(Long groupId, LinkImg linkImg) { // 해당 링크 이미지 삭제했을 떄 다른 이미지로 바꾸는 등의 작업 필요
+        GroupImg groupImg = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND))
+                .getGroupImg();
+        groupImgServiceImpl.initializeLinkImg(groupImg,linkImg);
     }
 
     @Override
@@ -80,6 +89,7 @@ public class GroupServiceImpl implements GroupService {
         groupRepository.deleteById(groupId);
     }
 
+    @Override
     public GroupDto findGroupById(Long id){
         // 특정 북마크 ID에 해당하는 북마크 조회
         Group group = groupRepository.findById(id).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND)); // todo: 예외처리
@@ -97,7 +107,7 @@ public class GroupServiceImpl implements GroupService {
                 .toList();
     }
 
-
+    @Override
     public  List<LinkDto> getLinksByGroupId(Long groupId){
         Optional<Group> groupList = groupRepository.findByIdWithLinks(groupId);
 

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
@@ -1,10 +1,15 @@
 package com.beside.archivist.service.group;
 
 import com.beside.archivist.dto.group.LinkGroupDto;
+import com.beside.archivist.entity.group.LinkGroup;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public interface LinkGroupService {
     LinkGroupDto saveLinkGroup(LinkGroupDto linkGroupDto);
     void deleteLinkGroup(Long groupId);
+    List<LinkGroup> getLinkGroupsByGroupId(Long groupId);
+    void changeGroupImg(Long groupId);
 }

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
@@ -8,8 +8,10 @@ import java.util.List;
 
 @Service
 public interface LinkGroupService {
+    LinkGroup getLinkGroupById(Long userGroupId);
     LinkGroupDto saveLinkGroup(LinkGroupDto linkGroupDto);
     void deleteLinkGroup(Long groupId);
     List<LinkGroup> getLinkGroupsByGroupId(Long groupId);
     void changeGroupImg(Long groupId);
+    boolean checkGroupImg(LinkGroup linkGroup);
 }

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
@@ -13,5 +13,5 @@ public interface LinkGroupService {
     void deleteLinkGroup(Long groupId);
     List<LinkGroup> getLinkGroupsByGroupId(Long groupId);
     void changeGroupImg(Long groupId);
-    boolean checkGroupImg(LinkGroup linkGroup);
+    boolean checkGroupLinkImgEquality(LinkGroup linkGroup);
 }

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
@@ -56,7 +56,7 @@ public class LinkGroupServiceImpl implements LinkGroupService {
     @Override
     public void deleteLinkGroup(Long linkGroupId) {
         LinkGroup linkGroup = getLinkGroupById(linkGroupId);
-        boolean existImageCheck = checkGroupImg(linkGroup); // 기존에 저장된 이미지가 삭제하는 링크 이미지인 경우 true
+        boolean existImageCheck = checkGroupLinkImgEquality(linkGroup); // 기존에 저장된 이미지가 삭제하는 링크 이미지인 경우 true
 
         linkGroupRepository.deleteById(linkGroupId);
 
@@ -80,7 +80,7 @@ public class LinkGroupServiceImpl implements LinkGroupService {
             groupServiceImpl.changeToLinkImg(groupId, LinkImg.initializeDefaultLinkImg());
             return;
         } else if(!linkGroups.get(0).getGroup().getGroupImg().getImgUrl().equals("/image/linkDefaultImg.png")){
-            return; // 2. 링크 이미지로 되어있을 때는 변경 X 
+            return; // 2. 링크 이미지로 되어있을 때는 변경 X
         }
 
         Optional<Link> firstLink = linkGroups.stream()
@@ -92,7 +92,7 @@ public class LinkGroupServiceImpl implements LinkGroupService {
     }
 
     @Override // 그룹 내에서 삭제하는 링크 이미지와 그룹 이미지가 같을 때
-    public boolean checkGroupImg(LinkGroup linkGroup) {
+    public boolean checkGroupLinkImgEquality(LinkGroup linkGroup) {
         String linkImg = linkGroup.getLink().getLinkImg().getImgUrl();
         String groupImg = linkGroup.getGroup().getGroupImg().getImgUrl();
         return linkImg.equals(groupImg);

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
@@ -5,6 +5,7 @@ import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.LinkGroup;
 import com.beside.archivist.entity.link.Link;
 
+import com.beside.archivist.entity.link.LinkImg;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.group.GroupNotFoundException;
 import com.beside.archivist.exception.link.LinkNotFoundException;
@@ -34,6 +35,10 @@ public class LinkGroupServiceImpl implements LinkGroupService {
 
     private final GroupRepository groupRepository; // 서비스 구현체 가져와주세요! ( 비즈니스 로직과 데이터 접근 로직을 분리하기 위함 )
 
+    @Override
+    public LinkGroup getLinkGroupById(Long userGroupId) {
+        return linkGroupRepository.findById(userGroupId).orElseThrow(); // todo: 예외 처리
+    }
 
     @Override
     public LinkGroupDto saveLinkGroup(LinkGroupDto linkGroupDto)  {
@@ -50,24 +55,46 @@ public class LinkGroupServiceImpl implements LinkGroupService {
 
     @Override
     public void deleteLinkGroup(Long linkGroupId) {
+        LinkGroup linkGroup = getLinkGroupById(linkGroupId);
+        boolean existImageCheck = checkGroupImg(linkGroup); // 기존에 저장된 이미지가 삭제하는 링크 이미지인 경우 true
+
         linkGroupRepository.deleteById(linkGroupId);
+
+        if(existImageCheck){ // 이미지 재설정
+            changeGroupImg(linkGroup.getGroup().getId());
+        }
     }
 
     @Override
     public List<LinkGroup> getLinkGroupsByGroupId(Long groupId) {
         return linkGroupRepository.findByGroup_Id(groupId);
     }
+
+    /** link가 그룹에서 빠졌을 때나 link 가 삭제되었을 경우
+     *  todo: 링크 이미지가 바뀌었을 때도 추가
+     * **/
     @Override
     public void changeGroupImg(Long groupId){
         List<LinkGroup> linkGroups = getLinkGroupsByGroupId(groupId);
-        if(!linkGroups.get(0).getGroup().getGroupImg().getImgUrl().equals("/image/linkDefaultImg.png")){
-            return; // 링크 이미지로 되어있을 때는 return; ( 변경 X )
+        if(linkGroups.isEmpty()){ // 1. 아무것도 없을 때는 디폴트 이미지로
+            groupServiceImpl.changeToLinkImg(groupId, LinkImg.initializeDefaultLinkImg());
+            return;
+        } else if(!linkGroups.get(0).getGroup().getGroupImg().getImgUrl().equals("/image/linkDefaultImg.png")){
+            return; // 2. 링크 이미지로 되어있을 때는 변경 X 
         }
+
         Optional<Link> firstLink = linkGroups.stream()
                 .map(LinkGroup::getLink)
-                .filter(link -> !link.getLinkUrl().equals("/image/linkDefaultImg.png"))
+                .filter(link -> !link.getLinkImg().getImgUrl().equals("/image/linkDefaultImg.png"))
                 .findFirst(); // 디폴트 이미지가 아닌 것 중 첫번째 Link return
+
         firstLink.ifPresent(link -> groupServiceImpl.changeToLinkImg(groupId, link.getLinkImg()));
     }
 
+    @Override // 그룹 내에서 삭제하는 링크 이미지와 그룹 이미지가 같을 때
+    public boolean checkGroupImg(LinkGroup linkGroup) {
+        String linkImg = linkGroup.getLink().getLinkImg().getImgUrl();
+        String groupImg = linkGroup.getGroup().getGroupImg().getImgUrl();
+        return linkImg.equals(groupImg);
+    }
 }

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
@@ -16,6 +16,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -27,10 +28,11 @@ public class LinkGroupServiceImpl implements LinkGroupService {
     private final LinkGroupRepository linkGroupRepository;
 
     private final LinkGroupMapper linkGroupMapperImpl;
+    private final GroupService groupServiceImpl;
 
-    private final LinkRepository linkRepository;
+    private final LinkRepository linkRepository; // 서비스 구현체 가져와주세요! ( 비즈니스 로직과 데이터 접근 로직을 분리하기 위함 )
 
-    private final GroupRepository groupRepository;
+    private final GroupRepository groupRepository; // 서비스 구현체 가져와주세요! ( 비즈니스 로직과 데이터 접근 로직을 분리하기 위함 )
 
 
     @Override
@@ -50,4 +52,22 @@ public class LinkGroupServiceImpl implements LinkGroupService {
     public void deleteLinkGroup(Long linkGroupId) {
         linkGroupRepository.deleteById(linkGroupId);
     }
+
+    @Override
+    public List<LinkGroup> getLinkGroupsByGroupId(Long groupId) {
+        return linkGroupRepository.findByGroup_Id(groupId);
+    }
+    @Override
+    public void changeGroupImg(Long groupId){
+        List<LinkGroup> linkGroups = getLinkGroupsByGroupId(groupId);
+        if(!linkGroups.get(0).getGroup().getGroupImg().getImgUrl().equals("/image/linkDefaultImg.png")){
+            return; // 링크 이미지로 되어있을 때는 return; ( 변경 X )
+        }
+        Optional<Link> firstLink = linkGroups.stream()
+                .map(LinkGroup::getLink)
+                .filter(link -> !link.getLinkUrl().equals("/image/linkDefaultImg.png"))
+                .findFirst(); // 디폴트 이미지가 아닌 것 중 첫번째 Link return
+        firstLink.ifPresent(link -> groupServiceImpl.changeToLinkImg(groupId, link.getLinkImg()));
+    }
+
 }

--- a/src/main/java/com/beside/archivist/service/link/LinkImgServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkImgServiceImpl.java
@@ -21,11 +21,7 @@ public class LinkImgServiceImpl implements LinkImgService {
 
     @Override
     public LinkImg initializeDefaultImg() {
-        return linkImgRepository.save(LinkImg.builder()
-                .oriImgName("linkDefaultImg.png")
-                .imgName("linkDefaultImg")
-                .imgUrl("/image/linkDefaultImg.png")
-                .build());
+        return linkImgRepository.save(LinkImg.initializeDefaultLinkImg());
     }
 
     public LinkImg insertLinkImg(MultipartFile linkImgFile) {


### PR DESCRIPTION
그룹 썸네일 예외 처리 (#78)
재사용성을 고려하여 *Img 클래스에 정적 팩터리 메서드 추가 (#113)

### 주요 변경 사항 
- 재사용성을 고려하여 *ImgService 에 정의된 DefaultImage() 내 로직을 정적 팩터리 메서드로 재정의 ( GroupImg, LinkImg )
- 그룹 생성 ( 처음에 이미지 업로드 안했을 때 링크 저장 안되어있으니까 링크 디폴트 이미지 저장 - 기존과 동일 )
- 그룹에 링크를 추가했을 때
  1. 링크가 디폴트 이미지일 때 -> 디폴트 이미지 유지
  2. 링크가 디폴트 이미지가 아닐 때 -> 링크 이미지로 업데이트
- 그룹 내 링크를 삭제했을 때
  1. 링크 이미지와 그룹 이미지가 같을 때 -> 기존 이미지가 아닌 새로운 링크 이미지로 업데이트 ( 위의 로직을 따라갑니다. ) 
  2. 링크 이미지와 그룹 이미지가 다를 때 -> 기존 이미지 유지

### 고려 사항
- 현재 #114 의 문제가 발생하여 링크 삭제했을 때의 로직을 추가하지 못했습니다! 하기 이슈 처리해주시면 진행할게요.
- 코드 가독성 및 description 이 괜찮은가 에 대한 코멘트도 부탁드려요! 