### PR TITLE
feat: 요청 헤더에 인증 토큰이 없는 경우 예외 처리 (#109)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -8,6 +8,7 @@ import com.beside.archivist.entity.users.Category;
 import com.beside.archivist.entity.users.UserImg;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.users.EmailTokenMismatchException;
+import com.beside.archivist.exception.users.MissingAuthenticationException;
 import com.beside.archivist.service.users.UserImgService;
 import com.beside.archivist.service.users.UserService;
 import com.beside.archivist.utils.JwtTokenUtil;
@@ -74,6 +75,9 @@ public class UserController {
     @GetMapping("/user")
     @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<?> getUserInfo(Authentication authentication) {
+        if (authentication == null){
+            throw new MissingAuthenticationException(ExceptionCode.MISSING_AUTHENTICATION);
+        }
         UserInfoDto userInfo = userServiceImpl.getUserInfo(authentication.getName());
         return ResponseEntity.ok().body(userInfo);
     }

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -17,6 +17,7 @@ public enum ExceptionCode {
     USER_NOT_FOUND(NOT_FOUND,"USER_003","사용자 정보가 존재하지 않습니다."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     AUTHORIZATION_CODE_EXPIRED(BAD_REQUEST, "USER_005", "인가 코드가 만료되었습니다. 재발급 받아주세요."),
+    MISSING_AUTHENTICATION(UNAUTHORIZED, "USER_006", "요청 헤더에 인증 토큰을 포함시켜 주세요."),
 
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
   

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -117,6 +117,16 @@ public class GlobalExceptionController {
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }
 
+    /** USER_006 토큰 인증 시 요청 헤더에 토큰이 없는 경우 **/
+    @ExceptionHandler(MissingAuthenticationException.class)
+    protected ResponseEntity<ExceptionDto> handlerMissingAuthenticationException(MissingAuthenticationException ex) {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ex.getExceptionCode().getStatus().value())
+                .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
     /** CATEGORY_001 정의되지 않은 카테고리 값 체크 **/
     @ExceptionHandler(InvalidCategoryNameException.class)
     protected ResponseEntity<ExceptionDto> handlerInvalidCategoryNameException(InvalidCategoryNameException ex) {

--- a/src/main/java/com/beside/archivist/exception/users/MissingAuthenticationException.java
+++ b/src/main/java/com/beside/archivist/exception/users/MissingAuthenticationException.java
@@ -1,0 +1,11 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MissingAuthenticationException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
@@ -9,6 +9,7 @@ import com.beside.archivist.entity.users.User;
 
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.link.LinkNotFoundException;
+import com.beside.archivist.exception.users.MissingAuthenticationException;
 import com.beside.archivist.exception.users.UserNotFoundException;
 import com.beside.archivist.mapper.LinkMapper;
 import com.beside.archivist.repository.link.LinkRepository;
@@ -40,8 +41,8 @@ public class LinkServiceImpl implements LinkService {
 
     @Override
     public LinkDto saveLink(LinkDto linkDto, MultipartFile linkImgFile)  {
-        Optional<String> authentication = auditConfig.auditorProvider().getCurrentAuditor();
-        String email = authentication.get();
+        String email = auditConfig.auditorProvider().getCurrentAuditor().orElseThrow(
+                () ->  new MissingAuthenticationException(ExceptionCode.MISSING_AUTHENTICATION));
         User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND));
 
         LinkImg linkImg = null;

--- a/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
@@ -1,8 +1,9 @@
 package com.beside.archivist.service.usergroup;
 
 import com.beside.archivist.config.AuditConfig;
-import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.usergroup.UserGroup;
+import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.users.MissingAuthenticationException;
 import com.beside.archivist.repository.usergroup.UserGroupRepository;
 import com.beside.archivist.service.group.GroupService;
 import com.beside.archivist.service.users.UserService;
@@ -22,7 +23,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     @Override
     public void saveUserGroup(Long groupId) {
         String userEmail = auditConfig.auditorProvider().getCurrentAuditor()
-                .orElseThrow(RuntimeException::new); // todo: 인증 X, 예외 처리
+                .orElseThrow(()-> new MissingAuthenticationException(ExceptionCode.MISSING_AUTHENTICATION));
 
         UserGroup userGroup = UserGroup.builder()
                 .isOwner(true) // 내가 생성한 그룹


### PR DESCRIPTION
요청 헤더에 인증 토큰이 없는 경우 예외 처리 (#109)

### 주요 변경 사항
- Service / Controller 단에서 토큰을 통해 유저 정보를 처리하는 경우에 Authentication 이 null 값으로 들어와 예외 처리 ( USER_006 )

### 고려 사항
- filter 단에서 Map 으로 응답하는 인증 관련 응답은 이슈 따로 파서 예외 코드 정의하고 리팩토링 하겠습니다!