### PR TITLE
관리자 계정 생성을 위한 권한 분리

### DIFF
--- a/src/main/java/com/beside/archivist/config/AuditorAwareImpl.java
+++ b/src/main/java/com/beside/archivist/config/AuditorAwareImpl.java
@@ -11,6 +11,8 @@ public class AuditorAwareImpl implements AuditorAware<String> {
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
+        //System.out.println("authentication ====="+authentication.getAuthorities());
+
         if (authentication == null || !authentication.isAuthenticated()) { // 인증이 안되어있다면
             return Optional.empty();
         }

--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -19,7 +19,6 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;

--- a/src/main/java/com/beside/archivist/config/filters/JwtRequestFilter.java
+++ b/src/main/java/com/beside/archivist/config/filters/JwtRequestFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collections;
 
 @Component
 public class JwtRequestFilter extends OncePerRequestFilter {
@@ -39,8 +41,13 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 if (StringUtils.isNoneEmpty(username) && null == SecurityContextHolder.getContext().getAuthentication()) {
                     UserDetails userDetails = userServiceImpl.loadUserByUsername(username);
                     if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
+                        String role = "USER"; // Default role
+                        if ("gudwls215@naver.com".equals(username)) {
+                            role = "ADMIN";
+                        }
+
                         UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                                new UsernamePasswordAuthenticationToken(userDetails, null, Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role)));
 
                         usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 

--- a/src/main/java/com/beside/archivist/entity/link/Link.java
+++ b/src/main/java/com/beside/archivist/entity/link/Link.java
@@ -3,12 +3,16 @@ package com.beside.archivist.entity.link;
 
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.entity.BaseEntity;
+import com.beside.archivist.entity.group.LinkGroup;
 import com.beside.archivist.entity.users.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity @Table(name = "link")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,6 +35,9 @@ public class Link extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "link_img_id")
     private LinkImg linkImg;
+
+    @OneToMany(mappedBy = "link", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LinkGroup> linkGroups = new ArrayList<>();
 
     @Builder
     public Link(String linkUrl, String linkName, String linkDesc, User user, LinkImg linkImg) {


### PR DESCRIPTION
관리자 계정 생성을 위한 권한 분리

### 주요 변경 사항
- 특정 email에 admin 권한 부여, 나머지는 user

### 고려 사항
- 추후에 관리자로 사용될 email로 수정
- 하드코딩으로 되어 있어 db에서 user 권한을 설정하는 방법도 고려해봐야함