### PR TITLE
refactor: Entity 내 모든 boolean 필드 타입 변경 (#126)

### DIFF
--- a/src/main/java/com/beside/archivist/dto/group/GroupDto.java
+++ b/src/main/java/com/beside/archivist/dto/group/GroupDto.java
@@ -17,13 +17,13 @@ public class GroupDto {
     private String groupName;           //그룹 이름
     @Size( max = 400, message = "그룹 설명은 400자 이내 이여야 합니다.")
     private String groupDesc;           //그룹 설명
-    private Boolean isGroupPublic;      //그룹 공개 여부
+    private String isGroupPublic;      //그룹 공개 여부
     private List<Category> categories;  //그룹 카테고리
     private String imgUrl;
     private Long linkCount;
 
     @Builder
-    public GroupDto(Long groupId, String groupName, String groupDesc, Boolean isGroupPublic, List<Category> categories, String imgUrl, Long linkCount) {
+    public GroupDto(Long groupId, String groupName, String groupDesc, String isGroupPublic, List<Category> categories, String imgUrl, Long linkCount) {
         this.groupId = groupId;
         this.groupName = groupName.trim();
         this.groupDesc = groupDesc;

--- a/src/main/java/com/beside/archivist/entity/BaseEntity.java
+++ b/src/main/java/com/beside/archivist/entity/BaseEntity.java
@@ -3,19 +3,13 @@ package com.beside.archivist.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.CreatedBy;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 
 @Getter
 @MappedSuperclass
@@ -29,7 +23,8 @@ public abstract class BaseEntity extends BaseTimeEntity{
     @LastModifiedBy
     private String lastModifiedBy;
 
-    @ColumnDefault("0") //default 0
-    private boolean isDeleted;
+    @ColumnDefault("'N'") // default N
+    private String isDeleted;
+
 }
 

--- a/src/main/java/com/beside/archivist/entity/group/Group.java
+++ b/src/main/java/com/beside/archivist/entity/group/Group.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Entity @Table(name = "group_info")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert @DynamicUpdate
 @SQLDelete(sql = "UPDATE group_info SET is_deleted = 'Y', deleted_at = sysdate() WHERE group_id = ?")
 @Where(clause = "is_deleted = 'N'")
 public class Group extends BaseEntity {

--- a/src/main/java/com/beside/archivist/entity/group/Group.java
+++ b/src/main/java/com/beside/archivist/entity/group/Group.java
@@ -5,22 +5,21 @@ import com.beside.archivist.entity.BaseEntity;
 import com.beside.archivist.entity.usergroup.UserGroup;
 import com.beside.archivist.entity.users.Category;
 import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.Formula;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
+import org.hibernate.annotations.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity @Table(name = "group_info")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE group_info SET is_deleted = true, deleted_at = sysdate() WHERE group_id = ?")
-@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE group_info SET is_deleted = 'Y', deleted_at = sysdate() WHERE group_id = ?")
+@Where(clause = "is_deleted = 'N'")
 public class Group extends BaseEntity {
 
     @Id @Column(name = "group_id")
@@ -32,8 +31,8 @@ public class Group extends BaseEntity {
     @Column(columnDefinition = "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
     private String groupDesc;
     @Column
-    @ColumnDefault("0") //default 0
-    private boolean isGroupPublic;
+    @ColumnDefault("'Y'") //default Y
+    private String isGroupPublic;
     @Column
     private List<Category> categories;
     @Formula("(SELECT COUNT(lg.link_group_id) FROM link_group lg WHERE lg.group_id = group_id)")
@@ -44,14 +43,14 @@ public class Group extends BaseEntity {
     private GroupImg groupImg;
 
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
-    private List<LinkGroup> links;
+    private List<LinkGroup> links = new ArrayList<>();
 
     @OneToMany(mappedBy = "groups", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserGroup> userGroups = new ArrayList<>();
 
 
     @Builder
-    public Group(String groupName, String groupDesc, Boolean isGroupPublic, List<Category> categories,GroupImg groupImg, Long linkCount, List<LinkGroup> links) {
+    public Group(String groupName, String groupDesc, String isGroupPublic, List<Category> categories,GroupImg groupImg, Long linkCount, List<LinkGroup> links) {
         this.groupName = groupName;
         this.groupDesc = groupDesc;
         this.isGroupPublic = isGroupPublic;

--- a/src/main/java/com/beside/archivist/entity/link/Link.java
+++ b/src/main/java/com/beside/archivist/entity/link/Link.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 @Entity @Table(name = "link")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert @DynamicUpdate
 @SQLDelete(sql = "UPDATE link SET is_deleted = 'Y', deleted_at = sysdate() WHERE link_id = ?")
 @Where(clause = "is_deleted = 'N'")
 public class Link extends BaseEntity {

--- a/src/main/java/com/beside/archivist/entity/link/Link.java
+++ b/src/main/java/com/beside/archivist/entity/link/Link.java
@@ -10,6 +10,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -18,8 +20,8 @@ import java.util.List;
 
 @Entity @Table(name = "link")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE link SET is_deleted = true, deleted_at = sysdate() WHERE link_id = ?")
-@Where(clause = "is_deleted = false")
+@SQLDelete(sql = "UPDATE link SET is_deleted = 'Y', deleted_at = sysdate() WHERE link_id = ?")
+@Where(clause = "is_deleted = 'N'")
 public class Link extends BaseEntity {
 
     @Id @Column(name = "link_id")

--- a/src/main/java/com/beside/archivist/entity/usergroup/UserGroup.java
+++ b/src/main/java/com/beside/archivist/entity/usergroup/UserGroup.java
@@ -1,6 +1,5 @@
 package com.beside.archivist.entity.usergroup;
 
-import com.beside.archivist.entity.BaseEntity;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.users.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -40,7 +40,7 @@ public class GroupServiceImpl implements GroupService {
         Group group = Group.builder()
                 .groupName(groupDto.getGroupName())
                 .groupDesc(groupDto.getGroupDesc())
-                .isGroupPublic(groupDto.getIsGroupPublic())
+                .isGroupPublic(groupDto.getIsGroupPublic()) // Y or N
                 .categories(groupDto.getCategories())
                 .groupImg(groupImg)
                 .linkCount(0L)


### PR DESCRIPTION
Entity 내 모든 boolean 필드 타입 변경 (#126)

### 주요 변경 사항
- Group 내 isGroupPublic 타입 변경 ( Default "Y" )
- BaseEntity 내 isDeleted 타입 변경 ( Default "N" )
- @ColumnDefault 값 적용을 위해 @DynamoInsert 어노테이션 추가
- 삭제 시 값을 업데이트하기 위해 @DynamoUpdate 어노테이션 추가

### 고려 사항
- User Entity 는 BaseEntity 를 상속받고 있지 않습니다. Soft Delete 적용 범위 확인 부탁드립니다!