### PR TITLE
refactor: 토큰 관련 예외 처리 재정의 (#134)

### DIFF
--- a/src/main/java/com/beside/archivist/config/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/beside/archivist/config/AuthenticationEntryPointImpl.java
@@ -1,5 +1,7 @@
 package com.beside.archivist.config;
 
+import com.beside.archivist.dto.exception.ExceptionDto;
+import com.beside.archivist.exception.common.ExceptionCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,8 +11,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
@@ -21,9 +21,11 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType("application/json; charset=UTF-8");
 
-        Map<Integer, String> responseError = new HashMap<>();
-        responseError.put(HttpStatus.UNAUTHORIZED.value(), "토큰 인증에 실패하였습니다.");
-        String responseMsg = mapper.writeValueAsString(responseError);
-        response.getWriter().write(responseMsg);
+        final ExceptionDto exceptionDto = ExceptionDto.builder()
+                .statusCode(ExceptionCode.INVALID_TOKEN.getStatus().value())
+                .message(ExceptionCode.INVALID_TOKEN.getMessage())
+                .build();
+
+        response.getWriter().write(mapper.writeValueAsString(exceptionDto));
     }
 }

--- a/src/main/java/com/beside/archivist/config/filters/JwtRequestFilter.java
+++ b/src/main/java/com/beside/archivist/config/filters/JwtRequestFilter.java
@@ -1,10 +1,10 @@
 package com.beside.archivist.config.filters;
 
+import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.users.TokenExpiredException;
 import com.beside.archivist.service.users.UserService;
 import com.beside.archivist.utils.JwtTokenUtil;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -48,10 +48,8 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                                 .setAuthentication(usernamePasswordAuthenticationToken);
                     }
                 }
-            } catch (SignatureException e) {
-                throw new JwtException("잘못된 토큰입니다.");
             } catch (ExpiredJwtException e) {
-                throw new JwtException("토큰이 만료되었습니다.");
+                throw new TokenExpiredException(ExceptionCode.TOKEN_EXPIRED);
             } catch (Exception e) {
                 logger.warn(e.getMessage());
             }

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -18,6 +18,7 @@ public enum ExceptionCode {
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     AUTHORIZATION_CODE_EXPIRED(BAD_REQUEST, "USER_005", "인가 코드가 만료되었습니다. 재발급 받아주세요."),
     MISSING_AUTHENTICATION(UNAUTHORIZED, "USER_006", "요청 헤더에 인증 토큰을 포함시켜 주세요."),
+    TOKEN_EXPIRED(UNAUTHORIZED, "USER_007", "토큰이 만료되었습니다. 재발급 받아주세요."),
 
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
   

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -19,6 +19,7 @@ public enum ExceptionCode {
     AUTHORIZATION_CODE_EXPIRED(BAD_REQUEST, "USER_005", "인가 코드가 만료되었습니다. 재발급 받아주세요."),
     MISSING_AUTHENTICATION(UNAUTHORIZED, "USER_006", "요청 헤더에 인증 토큰을 포함시켜 주세요."),
     TOKEN_EXPIRED(UNAUTHORIZED, "USER_007", "토큰이 만료되었습니다. 재발급 받아주세요."),
+    INVALID_TOKEN(UNAUTHORIZED, "USER_008","토큰이 잘못되었거나 토큰에 대한 회원 정보가 존재하지 않습니다."),
 
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
   

--- a/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
+++ b/src/main/java/com/beside/archivist/exception/common/GlobalExceptionController.java
@@ -9,6 +9,7 @@ import com.beside.archivist.exception.images.InvalidFileExtensionException;
 import com.beside.archivist.exception.link.GroupInBookmarkNotFoundException;
 import com.beside.archivist.exception.link.LinkNotFoundException;
 import com.beside.archivist.exception.users.*;
+import io.jsonwebtoken.security.SignatureException;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -125,6 +126,16 @@ public class GlobalExceptionController {
         final ExceptionDto responseError = ExceptionDto.builder()
                 .statusCode(ex.getExceptionCode().getStatus().value())
                 .message(ex.getExceptionCode().getMessage())
+                .build();
+        return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
+    }
+
+    /** USER_008 JWT 가 잘못된 경우 **/
+    @ExceptionHandler(SignatureException.class)
+    protected ResponseEntity<ExceptionDto> handlerInvalidTokenException() {
+        final ExceptionDto responseError = ExceptionDto.builder()
+                .statusCode(ExceptionCode.INVALID_TOKEN.getStatus().value())
+                .message(ExceptionCode.INVALID_TOKEN.getMessage())
                 .build();
         return ResponseEntity.status(responseError.getStatusCode()).body(responseError);
     }

--- a/src/main/java/com/beside/archivist/exception/users/InvalidTokenException.java
+++ b/src/main/java/com/beside/archivist/exception/users/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class InvalidTokenException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/com/beside/archivist/exception/users/TokenExpiredException.java
+++ b/src/main/java/com/beside/archivist/exception/users/TokenExpiredException.java
@@ -1,0 +1,10 @@
+package com.beside.archivist.exception.users;
+
+import com.beside.archivist.exception.common.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor @Getter
+public class TokenExpiredException extends RuntimeException{
+    private final ExceptionCode exceptionCode;
+}


### PR DESCRIPTION
토큰 관련 예외 처리 재정의 (#134)

### 주요 변경 사항
- Map<Integer,String> 타입으로 정의된 응답 메시지를 예외 코드로 재정의 하여 재정의
- 토큰 만료 시 TokenExpiredException 발생 ( USER_007)
- 토큰이 잘못되었거나 그에 대한 회원 정보가 존재하지 않을 때 InvalidTokenException 발생( USER_008 )

### 고려 사항
- Filter 단에서 발생하는 예외는 Dispatcher Servlet이 처리하기 전에 발생하기 때문에 GlobalController 에서 처리가 불가하여 USER_007 은 추가하지 않았습니다. USER_008 을 추가한 이유는 회원 정보 저장 API 에서는 토큰 검증을 Controller 에서 하기 때문입니다.