### PR TITLE
chore: CORS 화이트리스트에 운영 및 테스트 도메인 추가 (#144)

### DIFF
--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig{
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("http://localhost:5220")); // 추후 배포 주소로 변경
+        configuration.setAllowedOrigins(List.of("http://localhost:5220","http://arcave-official.com/","http://test.arcave-official.com","http://stage.arcave-official.com")); // 추후 배포 주소로 변경
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("*"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));


### PR DESCRIPTION
CORS 화이트리스트에 운영 및 테스트 도메인 추가 (#144)


### 주요 변경 사항
- 운영 도메인 추가 ( http://arcave-official.com/ )
- 테스트 도메인 추가 ( http://test.arcave-official.com, http://stage.arcave-official.com )