### PR TITLE
링크 초기 저장 시 그룹 이미지 업데이트 안되는 버그 수정 (#154)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/link/LinkController.java
+++ b/src/main/java/com/beside/archivist/controller/link/LinkController.java
@@ -3,6 +3,7 @@ package com.beside.archivist.controller.link;
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
+import com.beside.archivist.service.group.LinkGroupService;
 import com.beside.archivist.service.link.LinkService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -16,7 +17,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import org.apache.commons.validator.routines.UrlValidator;
 
-import java.util.Arrays;
 import java.util.List;
 
 
@@ -26,6 +26,7 @@ import java.util.List;
 public class LinkController {
 
     private final LinkService linkServiceImpl;
+    private final LinkGroupService linkGroupServiceImpl;
 
     /** 회원이 저장한 링크 모두 조회 **/
     @GetMapping("/user/link/{userId}")
@@ -76,6 +77,7 @@ public class LinkController {
                                           @RequestPart(value = "linkImgFile", required = false) MultipartFile linkImgFile) {
 
         LinkDto savedLink = linkServiceImpl.saveLink(linkDto,groupId,linkImgFile);
+        linkGroupServiceImpl.changeGroupImgArray(groupId); // 그룹 이미지 업데이트
         return ResponseEntity.status(HttpStatus.CREATED).body(savedLink);
     }
 

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupService.java
@@ -14,5 +14,6 @@ public interface LinkGroupService {
     void deleteLinkGroupByLinkId(Long linkId);
     List<LinkGroup> getLinkGroupsByGroupId(Long groupId);
     void changeGroupImg(Long groupId);
+    void changeGroupImgArray(Long[] groupIdArray);
     boolean checkGroupLinkImgEquality(LinkGroup linkGroup);
 }

--- a/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/LinkGroupServiceImpl.java
@@ -108,6 +108,13 @@ public class LinkGroupServiceImpl implements LinkGroupService {
         firstLink.ifPresent(link -> groupServiceImpl.changeToLinkImg(groupId, link.getLinkImg()));
     }
 
+    @Override
+    public void changeGroupImgArray(Long[] groupIdArray) {  // 그룹 ID 가 여러 개인 경우
+        for (Long groupId : groupIdArray) {
+            changeGroupImg(groupId);
+        }
+    }
+
     @Override // 그룹 내에서 삭제하는 링크 이미지와 그룹 이미지가 같을 때
     public boolean checkGroupLinkImgEquality(LinkGroup linkGroup) {
         String linkImg = linkGroup.getLink().getLinkImg().getImgUrl();


### PR DESCRIPTION
링크 초기 저장 시 그룹 이미지 업데이트 안되는 버그 수정 (#154)

### 주요 변경 사항
- groupId 배열을 매개변수로 하는 changeGroupImgArray 인터페이스 추가
- 링크 저장 시 그룹 이미지 업데이트 안되는 버그 수정

### 고려 사항
- 링크 삭제했을 때 그룹 이미지 업데이트 코드 추가 예정