### PR TITLE
Group-GroupImg 관계 재설정 및 코드 변경

### DIFF
--- a/src/main/java/com/beside/archivist/entity/group/Group.java
+++ b/src/main/java/com/beside/archivist/entity/group/Group.java
@@ -39,8 +39,7 @@ public class Group extends BaseEntity {
     @Formula("(SELECT COUNT(lg.link_group_id) FROM link_group lg WHERE lg.group_id = group_id)")
     private Long linkCount;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_img_id")
+    @OneToOne(mappedBy = "group",fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private GroupImg groupImg;
 
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
@@ -51,12 +50,11 @@ public class Group extends BaseEntity {
 
 
     @Builder
-    public Group(String groupName, String groupDesc, String isGroupPublic, List<Category> categories,GroupImg groupImg, Long linkCount, List<LinkGroup> links) {
+    public Group(String groupName, String groupDesc, String isGroupPublic, List<Category> categories, Long linkCount, List<LinkGroup> links) {
         this.groupName = groupName;
         this.groupDesc = groupDesc;
         this.isGroupPublic = isGroupPublic;
         this.categories = categories;
-        this.groupImg = groupImg;
         this.linkCount = linkCount;
         this.links = links;
     }
@@ -70,5 +68,8 @@ public class Group extends BaseEntity {
 
     public void addUserGroup(UserGroup userGroup) {
         this.userGroups.add(userGroup);
+    }
+    public void saveGroupImg(GroupImg groupImg){
+        this.groupImg = groupImg;
     }
 }

--- a/src/main/java/com/beside/archivist/entity/group/GroupImg.java
+++ b/src/main/java/com/beside/archivist/entity/group/GroupImg.java
@@ -19,7 +19,8 @@ public class GroupImg {
     private String oriImgName; // 원본 이미지 파일명
     private String imgUrl; // 이미지 조회 경로
 
-    @OneToOne(mappedBy = "groupImg", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
     private Group group;
 
     @Builder
@@ -39,5 +40,8 @@ public class GroupImg {
                 .oriImgName("linkDefaultImg.png")
                 .imgUrl("/image/linkDefaultImg.png")
                 .build();
+    }
+    public void saveGroup(Group group) {
+        this.group = group;
     }
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgService.java
@@ -8,8 +8,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public interface GroupImgService {
 
-    GroupImg initializeDefaultLinkImg();
+    GroupImg saveGroupImg(GroupImg groupImg);
     void changeToLinkImg(GroupImg groupImg, LinkImg linkImg);
-    GroupImg insertGroupImg(MultipartFile groupImgFile);
+    GroupImg insertGroupImg(GroupImg groupImg, MultipartFile groupImgFile);
     void changeLinkImg(Long groupImgId, MultipartFile groupImgFile);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgService.java
@@ -11,5 +11,5 @@ public interface GroupImgService {
     GroupImg saveGroupImg(GroupImg groupImg);
     void changeToLinkImg(GroupImg groupImg, LinkImg linkImg);
     GroupImg insertGroupImg(GroupImg groupImg, MultipartFile groupImgFile);
-    void changeLinkImg(Long groupImgId, MultipartFile groupImgFile);
+    void changeGroupImg(Long groupImgId, MultipartFile groupImgFile);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
@@ -22,9 +22,16 @@ public class GroupImgServiceImpl implements GroupImgService {
     private final GroupImgRepository groupImgRepository;
     private final FileService fileService;
 
+    /**
+     * 이미지 설정 안했을 때 초기 그룹 이미지는 링크 디폴트 이미지로 저장
+     * @param groupImg
+     * @return
+     */
     @Override
-    public GroupImg initializeDefaultLinkImg() {
-        return groupImgRepository.save(GroupImg.initializeDefaultLinkImg());
+    public GroupImg saveGroupImg(GroupImg groupImg) {
+        GroupImg savedGroupImg = groupImgRepository.save(groupImg);
+        savedGroupImg.getGroup().saveGroupImg(savedGroupImg);
+        return savedGroupImg;
     }
     @Override
     public void changeToLinkImg(GroupImg groupImg, LinkImg linkImg) {
@@ -32,20 +39,16 @@ public class GroupImgServiceImpl implements GroupImgService {
     }
 
     @Override
-    public GroupImg insertGroupImg(MultipartFile groupImgFile) {
-        if(groupImgFile != null){
+    public GroupImg insertGroupImg(GroupImg groupImg, MultipartFile groupImgFile) {
+        String oriImgName = groupImgFile.getOriginalFilename();
+        String imgName = fileService.uploadFile(groupImgLocation, groupImgFile);
+        String imgUrl = "/images/groups/"+imgName;
 
-            String oriImgName = groupImgFile.getOriginalFilename();
-            String imgName = fileService.uploadFile(groupImgLocation, groupImgFile);
-            String imgUrl = "/images/groups/"+imgName;
-            return groupImgRepository.save(GroupImg.builder()
-                    .oriImgName(oriImgName)
-                    .imgName(imgName)
-                    .imgUrl(imgUrl)
-                    .build());
-        }else {
-            return null;
-        }
+        groupImg.updateGroupImg(imgName,oriImgName,imgUrl);
+        GroupImg savedGroupImg = groupImgRepository.save(groupImg);
+        savedGroupImg.getGroup().saveGroupImg(savedGroupImg);
+
+        return savedGroupImg;
     }
 
     @Override

--- a/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupImgServiceImpl.java
@@ -52,7 +52,7 @@ public class GroupImgServiceImpl implements GroupImgService {
     }
 
     @Override
-    public void changeLinkImg(Long groupImgId, MultipartFile groupImgFile) {
+    public void changeGroupImg(Long groupImgId, MultipartFile groupImgFile) {
         if(groupImgFile != null){
             GroupImg savedGroupImg = groupImgRepository.findById(groupImgId)
                     .orElseThrow(() -> new ImageNotFoundException(ExceptionCode.IMAGE_NOT_FOUND));

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -71,7 +71,7 @@ public class GroupServiceImpl implements GroupService {
 //            }else{
 //                groupImgServiceImpl.changeLinkImg(group.getGroupImg().getId(), groupImgFile);
 //            }
-            groupImgServiceImpl.changeLinkImg(group.getGroupImg().getId(), groupImgFile);
+            groupImgServiceImpl.changeGroupImg(group.getGroupImg().getId(), groupImgFile);
         }
 
         group.update(GroupDto.builder()

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -28,6 +28,12 @@ public class GroupServiceImpl implements GroupService {
     private final GroupImgService groupImgServiceImpl;
     private final GroupMapper groupMapperImpl;
 
+    /**
+     * 그룹 생성 - 이미지 없을 때는 디폴트 이미지로 저장
+     * @param groupDto
+     * @param groupImgFile
+     * @return GroupDto
+     */
     @Override
     public GroupDto saveGroup(GroupDto groupDto, MultipartFile groupImgFile)  {
 
@@ -53,6 +59,11 @@ public class GroupServiceImpl implements GroupService {
         return groupMapperImpl.toDto(savedGroup);
     }
 
+    /**
+     * 그룹 이미지가 없을 때 내부 링크 이미지 중 하나로 변경
+     * @param groupId
+     * @param linkImg
+     */
     @Override
     public void changeToLinkImg(Long groupId, LinkImg linkImg) { // 해당 링크 이미지 삭제했을 떄 다른 이미지로 바꾸는 등의 작업 필요
         GroupImg groupImg = groupRepository.findById(groupId)
@@ -61,6 +72,13 @@ public class GroupServiceImpl implements GroupService {
         groupImgServiceImpl.changeToLinkImg(groupImg,linkImg); // groupImg -> linkImg 로 변경
     }
 
+    /**
+     * 그룹 정보 수정
+     * @param groupId
+     * @param groupDto
+     * @param groupImgFile
+     * @return GroupDto
+     */
     @Override
     public GroupDto updateGroup(Long groupId, GroupDto groupDto, MultipartFile groupImgFile) {
         Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
@@ -83,25 +101,43 @@ public class GroupServiceImpl implements GroupService {
         return groupMapperImpl.toDto(group);
     }
 
+    /**
+     * 그룹 단일 조회
+     * @param groupId
+     * @return Group
+     */
     @Override
     public Group getGroup(Long groupId) {
         return groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
     }
 
+    /**
+     * 그룹 삭제
+     * @param groupId
+     */
     @Override
     public void deleteGroup(Long groupId) {
         groupRepository.deleteById(groupId);
     }
 
+    /**
+     * 그룹 단일 조회
+     * @param id
+     * @return GroupDto
+     */
     @Override
     public GroupDto findGroupById(Long id){
-        // 특정 북마크 ID에 해당하는 북마크 조회
         Group group = groupRepository.findById(id).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
         return groupMapperImpl.toDto(group);
     }
 
+    /**
+     * 특정 그룹 내 모든 링크 조회
+     * @param groupId
+     * @return List<LinkDto>
+     */
     @Override
-    public  List<LinkDto> getLinksByGroupId(Long groupId){
+    public List<LinkDto> getLinksByGroupId(Long groupId){
         Optional<Group> groupList = groupRepository.findByIdWithLinks(groupId);
 
         return groupList.orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND))

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -84,11 +84,6 @@ public class GroupServiceImpl implements GroupService {
         Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
 
         if(groupImgFile != null){
-//            if(group.getGroupImg() == null){ // 초기 Group 생성 시 GroupImg 필수 생성 입니다. ( 없으면 오류 )
-//                groupImgServiceImpl.insertGroupImg(groupImgFile);
-//            }else{
-//                groupImgServiceImpl.changeLinkImg(group.getGroupImg().getId(), groupImgFile);
-//            }
             groupImgServiceImpl.changeGroupImg(group.getGroupImg().getId(), groupImgFile);
         }
 


### PR DESCRIPTION
Group-GroupImg 관계 재설정 및 코드 변경 (#167)

### 주요 변경 사항
- Group-GroupImg 관계를 자식-부모 → 부모-자식 으로 변경
- 관계 재설정에 따라 서비스 코드 변경
- 메서드명 오타 수정 ( changeLinkImg → changeGroupImg )
- GroupService 내 Description 추가

### 고려 사항
- Link-LinkImg 관계 설정 확인