### PR TITLE
토큰 이슈와 회원 정보가 없는 경우 예외 분리 (#204)

### DIFF
--- a/src/main/java/com/beside/archivist/config/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/beside/archivist/config/AuthenticationEntryPointImpl.java
@@ -15,6 +15,13 @@ import java.io.IOException;
 @Component
 public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
 
+    /**
+     * 인증을 요구하는 API 에서 토큰이 없거나 JWT 가 아닌 경우
+     * @param request that resulted in an <code>AuthenticationException</code>
+     * @param response so that the user agent can begin authentication
+     * @param authException that caused the invocation
+     * @throws IOException
+     */
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
@@ -22,8 +29,8 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
         response.setContentType("application/json; charset=UTF-8");
 
         final ExceptionDto exceptionDto = ExceptionDto.builder()
-                .statusCode(ExceptionCode.INVALID_TOKEN.getStatus().value())
-                .message(ExceptionCode.INVALID_TOKEN.getMessage())
+                .statusCode(ExceptionCode.MISSING_AUTHENTICATION.getStatus().value())
+                .message(ExceptionCode.MISSING_AUTHENTICATION.getMessage())
                 .build();
 
         response.getWriter().write(mapper.writeValueAsString(exceptionDto));

--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -3,10 +3,7 @@ package com.beside.archivist.config;
 import com.beside.archivist.config.filters.JwtExceptionFilter;
 import com.beside.archivist.config.filters.JwtRequestFilter;
 import com.beside.archivist.service.users.UserService;
-import com.beside.archivist.utils.JwtTokenUtil;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -46,7 +43,7 @@ public class SecurityConfig{
         http
                 .authorizeHttpRequests(
                         request -> request
-                                .requestMatchers("/user").permitAll() // Controller 에서 인증
+                                .requestMatchers(HttpMethod.POST, "/user").permitAll() // Controller 에서 인증
                                 .requestMatchers("/user/**").authenticated()
                                 .requestMatchers(HttpMethod.GET, "/link/{linkId}").permitAll()
                                 .requestMatchers("/link","/link/{linkId}").authenticated()

--- a/src/main/java/com/beside/archivist/config/filters/JwtExceptionFilter.java
+++ b/src/main/java/com/beside/archivist/config/filters/JwtExceptionFilter.java
@@ -2,6 +2,7 @@ package com.beside.archivist.config.filters;
 
 import com.beside.archivist.dto.exception.ExceptionDto;
 import com.beside.archivist.exception.common.ExceptionCode;
+import com.beside.archivist.exception.users.InvalidTokenException;
 import com.beside.archivist.exception.users.TokenExpiredException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
@@ -9,6 +10,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -18,12 +20,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
+@Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
         try {
             chain.doFilter(request, response); // go to next filter
         } catch (TokenExpiredException e) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getExceptionCode());
+        } catch (InvalidTokenException e) {
             setErrorResponse(HttpStatus.UNAUTHORIZED, response, e.getExceptionCode());
         }
     }

--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -34,7 +34,6 @@ public class UserController {
 
     private final KakaoService kakaoServiceImpl;
     private final UserService userServiceImpl;
-    private final UserImgService userImgServiceImpl;
     private final JwtTokenUtil jwtTokenUtil;
 
     /** 카카오 로그인 - JWT 발급 */
@@ -74,9 +73,6 @@ public class UserController {
     @GetMapping("/user")
     @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
     public ResponseEntity<?> getUserInfo(Authentication authentication) {
-        if (authentication == null){
-            throw new MissingAuthenticationException(ExceptionCode.MISSING_AUTHENTICATION);
-        }
         UserInfoDto userInfo = userServiceImpl.getUserInfo(authentication.getName());
         return ResponseEntity.ok().body(userInfo);
     }

--- a/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
+++ b/src/main/java/com/beside/archivist/exception/common/ExceptionCode.java
@@ -18,9 +18,9 @@ public enum ExceptionCode {
     USER_NOT_FOUND(NOT_FOUND,"USER_003","사용자 정보가 존재하지 않습니다."),
     EMAIL_TOKEN_MISMATCH(FORBIDDEN, "USER_004", "회원과 토큰의 정보가 맞지 않습니다."),
     AUTHORIZATION_CODE_EXPIRED(BAD_REQUEST, "USER_005", "인가 코드가 만료되었습니다. 재발급 받아주세요."),
-    MISSING_AUTHENTICATION(UNAUTHORIZED, "USER_006", "요청 헤더에 인증 토큰을 포함시켜 주세요."),
+    MISSING_AUTHENTICATION(UNAUTHORIZED, "USER_006", "요청 헤더에 올바른 인증 토큰을 포함시켜 주세요."),
     TOKEN_EXPIRED(UNAUTHORIZED, "USER_007", "토큰이 만료되었습니다. 재발급 받아주세요."),
-    INVALID_TOKEN(UNAUTHORIZED, "USER_008","토큰이 잘못되었거나 토큰에 대한 회원 정보가 존재하지 않습니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "USER_008","토큰에 대한 회원 정보가 존재하지 않습니다."),
 
     INVALID_CATEGORY_NAME(BAD_REQUEST,"CATEGORY_001", "정의되지 않은 카테고리 값 입니다."),
   


### PR DESCRIPTION
회원 조회 시 토큰 이슈와 회원 정보가 없는 경우 예외 분리 (#204)

### 주요 변경 사항
- 회원 조회 API Controller 내 Authentication 검증 로직 제거
- 토큰에 대한 회원 정보가 없는 경우 ( INVALID_TOKEN ) 와 토큰이 없거나 JWT 가 아닌 경우 ( MISSING_AUTHENTICATION ) 분리