### PR TITLE
LinkDto 와 LinkInfoDto 중복되어 구분 및 정리 (#199)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/group/GroupController.java
+++ b/src/main/java/com/beside/archivist/controller/group/GroupController.java
@@ -1,7 +1,7 @@
 package com.beside.archivist.controller.group;
 
 import com.beside.archivist.dto.group.GroupDto;
-import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.users.MissingAuthenticationException;
 import com.beside.archivist.service.usergroup.UserGroupService;
@@ -78,7 +78,7 @@ public class GroupController {
     /** 특정 그룹에 속한 링크들 모두 조회 **/
     @GetMapping("/group/link/{groupId}")
     public ResponseEntity<?> getLinksByGroupId(@PathVariable("groupId") Long id) {
-        List<LinkDto> group = groupServiceImpl.getLinksByGroupId(id);
+        List<LinkInfoDto> group = groupServiceImpl.getLinksByGroupId(id);
         return ResponseEntity.ok().body(group);
     }
 }

--- a/src/main/java/com/beside/archivist/controller/link/LinkController.java
+++ b/src/main/java/com/beside/archivist/controller/link/LinkController.java
@@ -2,7 +2,6 @@ package com.beside.archivist.controller.link;
 
 import com.beside.archivist.dto.link.LinkDto;
 import com.beside.archivist.dto.link.LinkInfoDto;
-import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.users.MissingAuthenticationException;
 import com.beside.archivist.service.group.LinkGroupService;
@@ -21,7 +20,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.apache.commons.validator.routines.UrlValidator;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 
 @RestController
@@ -35,27 +33,15 @@ public class LinkController {
     /** 회원이 저장한 링크 모두 조회 **/
     @GetMapping("/user/link/{userId}")
     @Operation(security = { @SecurityRequirement(name = "bearerAuth") })
-    public ResponseEntity<List<LinkDto>> getUserLinkList(@PathVariable("userId") Long userId) {
-        List<LinkDto> links = linkServiceImpl.getLinksByUserId(userId);
+    public ResponseEntity<List<LinkInfoDto>> getUserLinkList(@PathVariable("userId") Long userId) {
+        List<LinkInfoDto> links = linkServiceImpl.getLinksByUserId(userId);
         return ResponseEntity.ok().body(links);
     }
 
     /** 특정 링크 상세 조회 **/
     @GetMapping("/link/{linkId}")
     public ResponseEntity<?> findLinkById(@PathVariable("linkId") Long linkId) {
-        LinkDto link = linkServiceImpl.findLinkById(linkId);
-        List<Group> groupList = linkServiceImpl.getGroupsByLinkId(linkId);
-
-        LinkInfoDto linkInfoDto = LinkInfoDto.builder()
-                .linkId(link.getLinkId())
-                .linkUrl(link.getLinkUrl())
-                .linkName(link.getLinkName())
-                .linkDesc(link.getLinkDesc())
-                .imgUrl(link.getImgUrl())
-                .userId(link.getUserId())
-                .groupList(groupList.stream().map(Group::getId).collect(Collectors.toList()))
-                .build();
-
+        LinkInfoDto linkInfoDto = linkServiceImpl.findLinkById(linkId);
         return ResponseEntity.ok().body(linkInfoDto);
     }
 
@@ -85,7 +71,7 @@ public class LinkController {
             throw new MissingAuthenticationException(ExceptionCode.MISSING_AUTHENTICATION);
         }
 
-        LinkDto savedLink = linkServiceImpl.saveLink(linkDto,groupIds,authentication.getName(),linkImgFile);
+        LinkInfoDto savedLink = linkServiceImpl.saveLink(linkDto,groupIds,authentication.getName(),linkImgFile);
         linkGroupServiceImpl.changeGroupImgArray(groupIds);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(savedLink);
@@ -98,7 +84,7 @@ public class LinkController {
                                             @RequestPart @Valid LinkDto linkDto,
                                             @RequestPart(value = "groupId") Long[] groupIds,
                                             @RequestPart(value = "linkImgFile", required = false) MultipartFile linkImgFile) {
-        LinkDto updatedLink = linkServiceImpl.updateLink(linkId, linkDto, groupIds, linkImgFile);
+        LinkInfoDto updatedLink = linkServiceImpl.updateLink(linkId, linkDto, groupIds, linkImgFile);
         return ResponseEntity.ok().body(updatedLink);
     }
 

--- a/src/main/java/com/beside/archivist/dto/link/LinkDto.java
+++ b/src/main/java/com/beside/archivist/dto/link/LinkDto.java
@@ -1,13 +1,11 @@
 package com.beside.archivist.dto.link;
 
-import com.beside.archivist.entity.users.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 
-@Getter @ToString
+@Getter
 public class LinkDto {
     private Long linkId;
     private String linkUrl;    //북마크 경로
@@ -16,16 +14,12 @@ public class LinkDto {
     private String linkName;   //북마크 이름
     @Size( max = 400, message = "link 설명은 400자 이내 이여야 합니다.")
     private String linkDesc;   //북마크 설명
-    private String imgUrl;
-    private Long userId;
 
     @Builder
-    public LinkDto(Long linkId, String linkUrl, String linkName, String linkDesc, String imgUrl,Long userId) {
+    public LinkDto(Long linkId, String linkUrl, String linkName, String linkDesc) {
         this.linkId = linkId;
         this.linkUrl = linkUrl;
         this.linkName = linkName.trim();
         this.linkDesc = linkDesc.trim();
-        this.imgUrl = imgUrl;
-        this.userId = userId;
     }
 }

--- a/src/main/java/com/beside/archivist/dto/link/LinkInfoDto.java
+++ b/src/main/java/com/beside/archivist/dto/link/LinkInfoDto.java
@@ -9,18 +9,14 @@ import lombok.ToString;
 
 import java.util.List;
 
-@Getter @ToString
+@Getter
 public class LinkInfoDto {
     private Long linkId;
     private String linkUrl;    //북마크 경로
-    @NotBlank(message = "link 이름은 공백일 수 없습니다.")
-    @Size(min = 1, max = 100, message = "link 이름은 1자에서 100자 사이 여야 합니다.")
     private String linkName;   //북마크 이름
-    @Size( max = 400, message = "link 설명은 400자 이내 이여야 합니다.")
     private String linkDesc;   //북마크 설명
     private String imgUrl;
     private Long userId;
-
     private List<Long> groupList;
 
     @Builder

--- a/src/main/java/com/beside/archivist/mapper/LinkMapper.java
+++ b/src/main/java/com/beside/archivist/mapper/LinkMapper.java
@@ -1,16 +1,30 @@
 package com.beside.archivist.mapper;
 
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
+import com.beside.archivist.entity.group.LinkGroup;
 import com.beside.archivist.entity.link.Link;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface LinkMapper {
     @Mapping(target = "linkId", source = "id")
     @Mapping(target = "userId", source = "users.id")
     @Mapping(target = "imgUrl", source = "linkImg.imgUrl")
-    LinkDto toDto(Link link);
+    @Mapping(target = "groupList", source = "linkGroups", qualifiedByName = "mapLinkGroupsToGroupList")
+    LinkInfoDto toDto(Link link);
     Link toEntity(LinkDto linkDto);
+
+    @Named("mapLinkGroupsToGroupList")
+    default List<Long> mapLinkGroupsToGroupList(List<LinkGroup> linkGroups) {
+        return linkGroups.stream()
+                .map(linkGroup -> linkGroup.getGroup().getId())
+                .toList();
+    }
+
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -1,10 +1,9 @@
 package com.beside.archivist.service.group;
 
 import com.beside.archivist.dto.group.GroupDto;
-import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.link.LinkImg;
-import com.beside.archivist.entity.usergroup.UserGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -19,7 +18,7 @@ public interface GroupService {
     GroupDto updateGroup(Long groupId, GroupDto groupDto, MultipartFile groupImgFile);
     Group getGroup(Long groupId);
     void deleteGroup(Long groupId);
-    List<LinkDto> getLinksByGroupId(Long groupId);
+    List<LinkInfoDto> getLinksByGroupId(Long groupId);
 
     void changeToLinkImg(Long groupId, LinkImg linkImg);
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -2,6 +2,7 @@ package com.beside.archivist.service.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.GroupImg;
 import com.beside.archivist.entity.link.LinkImg;
@@ -132,17 +133,19 @@ public class GroupServiceImpl implements GroupService {
      * @return List<LinkDto>
      */
     @Override
-    public List<LinkDto> getLinksByGroupId(Long groupId){
-        Optional<Group> groupList = groupRepository.findByIdWithLinks(groupId);
-
-        return groupList.orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND))
-                .getLinks().stream()
-                .map(m-> new LinkDto(m.getLink().getId(),
-                        m.getLink().getLinkUrl(),
-                        m.getLink().getLinkName(),
-                        m.getLink().getLinkDesc(),
-                        m.getLink().getLinkImg().getImgUrl(),
-                        m.getLink().getUsers().getId())
+    public List<LinkInfoDto> getLinksByGroupId(Long groupId){
+        Group findGroup = groupRepository.findByIdWithLinks(groupId)
+                .orElseThrow(() -> new GroupNotFoundException(ExceptionCode.GROUP_NOT_FOUND));
+        return findGroup.getLinkGroups()
+                .stream()
+                .map(m-> LinkInfoDto.builder()
+                            .linkId(m.getLink().getId())
+                            .linkName(m.getLink().getLinkName())
+                            .linkDesc(m.getLink().getLinkDesc())
+                            .linkUrl(m.getLink().getLinkUrl())
+                            .imgUrl(m.getLink().getLinkImg().getImgUrl())
+                            .userId(m.getLink().getUsers().getId())
+                            .build()
                 ).toList();
     }
 }

--- a/src/main/java/com/beside/archivist/service/link/LinkService.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkService.java
@@ -1,6 +1,7 @@
 package com.beside.archivist.service.link;
 
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,13 +10,13 @@ import java.util.List;
 
 @Service
 public interface LinkService {
-    LinkDto saveLink(LinkDto linkDto,Long[] groupIds,String email, MultipartFile linkImgFile);
-    LinkDto updateLink(Long linkId, LinkDto linkDto, Long[] groupIds, MultipartFile linkImgFile);
+    LinkInfoDto saveLink(LinkDto linkDto,Long[] groupIds,String email, MultipartFile linkImgFile);
+    LinkInfoDto updateLink(Long linkId, LinkDto linkDto, Long[] groupIds, MultipartFile linkImgFile);
     void deleteLink(Long linkId);
 
-    LinkDto findLinkById(Long linkId);
+    LinkInfoDto findLinkById(Long linkId);
 
-    List<LinkDto>  getLinksByUserId(Long userId);
+    List<LinkInfoDto>  getLinksByUserId(Long userId);
 
     List<Group> getGroupsByLinkId(Long linkId);
 }

--- a/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/link/LinkServiceImpl.java
@@ -2,6 +2,7 @@ package com.beside.archivist.service.link;
 
 import com.beside.archivist.dto.group.LinkGroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.group.LinkGroup;
 import com.beside.archivist.entity.link.Link;
@@ -44,7 +45,7 @@ public class LinkServiceImpl implements LinkService {
     private final UserRepository userRepository;
 
     @Override
-    public LinkDto saveLink(LinkDto linkDto, Long[] groupIds, String email, MultipartFile linkImgFile)  {
+    public LinkInfoDto saveLink(LinkDto linkDto, Long[] groupIds, String email, MultipartFile linkImgFile)  {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(ExceptionCode.USER_NOT_FOUND));
 
         Link savedLink = linkRepository.save(
@@ -64,7 +65,7 @@ public class LinkServiceImpl implements LinkService {
             linkImgService.saveLinkImg(linkImg);
         }
 
-//        linkGroupService.deleteLinkGroupByLinkId(savedLink.getId());
+        // 요청 받은 그룹에 모두 링크 연결
         for(Long groupId : groupIds){
             LinkGroupDto linkGroupDto = LinkGroupDto.builder().groupId(groupId).linkId(savedLink.getId()).build();
             linkGroupService.saveLinkGroup(linkGroupDto);
@@ -74,7 +75,7 @@ public class LinkServiceImpl implements LinkService {
     }
 
     @Override
-    public LinkDto updateLink(Long linkId, LinkDto linkDto, Long[] groupIds, MultipartFile linkImgFile) {
+    public LinkInfoDto updateLink(Long linkId, LinkDto linkDto, Long[] groupIds, MultipartFile linkImgFile) {
         Link link = linkRepository.findById(linkId).orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND));
 
         if(linkImgFile != null){
@@ -97,14 +98,14 @@ public class LinkServiceImpl implements LinkService {
         linkRepository.deleteById(linkId);
     }
     @Override
-    public LinkDto findLinkById(Long linkId){
+    public LinkInfoDto findLinkById(Long linkId){
         // 특정 북마크 ID에 해당하는 북마크 조회
         Link link = linkRepository.findById(linkId).orElseThrow(() -> new LinkNotFoundException(ExceptionCode.LINK_NOT_FOUND));
 
         return linkMapperImpl.toDto(link);
     }
     @Override
-    public List<LinkDto> getLinksByUserId(Long userId){
+    public List<LinkInfoDto> getLinksByUserId(Long userId){
         // 특정 사용자 ID에 해당하는 북마크 목록 조회
         List<Link> linkList = linkRepository.findByUsers_Id(userId);
 

--- a/src/test/java/com/beside/archivist/service/group/LinkGroupServiceTest.java
+++ b/src/test/java/com/beside/archivist/service/group/LinkGroupServiceTest.java
@@ -2,6 +2,7 @@ package com.beside.archivist.service.group;
 
 import com.beside.archivist.dto.group.GroupDto;
 import com.beside.archivist.dto.link.LinkDto;
+import com.beside.archivist.dto.link.LinkInfoDto;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.link.Link;
 import com.beside.archivist.entity.users.Category;
@@ -96,7 +97,7 @@ class LinkGroupServiceTest {
                 String.valueOf(MediaType.IMAGE_JPEG),
                 "Spring!".getBytes()
         );
-        LinkDto savedLinkDto = linkServiceImpl.saveLink(createLinkDto(),
+        LinkInfoDto savedLinkDto = linkServiceImpl.saveLink(createLinkDto(),
                 new Long[]{savedGroupDto.getGroupId()}, savedUser.getEmail(),linkImg);
 
         // when


### PR DESCRIPTION
LinkDto 와 LinkInfoDto 중복되어 구분 및 정리 (#199)

### 주요 변경 사항
- 용도 구분은 LinkDto : 요청DTO, LinkInfoDto : 응답DTO 로 정리
- LinkDto 내 불필요한 필드 제거 → linkUrl, linkName, linkDesc 외 모두 제거
- LinkInfoDto 내 유효성 검증 애노테이션 제거 → 검증을 통해 저장된 값을 응답하므로 검증 X
- 응답 값에 groupList 가 포함되어 LinkMapper 내 groupList 매핑 메서드 추가

### 고려 사항
- Link - Group 연결 시 양방향 저장이 안되어있어 fix 로 이슈 올리겠습니다.  → 저장 시 groupList 확인 불가.