### PR TITLE
회원 가입 시 기본 그룹 자동 생성 (#230)

### DIFF
--- a/src/main/java/com/beside/archivist/controller/users/UserController.java
+++ b/src/main/java/com/beside/archivist/controller/users/UserController.java
@@ -5,11 +5,9 @@ import com.beside.archivist.dto.users.KakaoLoginDto;
 import com.beside.archivist.dto.users.UserDto;
 import com.beside.archivist.dto.users.UserInfoDto;
 import com.beside.archivist.entity.users.Category;
-import com.beside.archivist.entity.users.UserImg;
 import com.beside.archivist.exception.common.ExceptionCode;
 import com.beside.archivist.exception.users.EmailTokenMismatchException;
-import com.beside.archivist.exception.users.MissingAuthenticationException;
-import com.beside.archivist.service.users.UserImgService;
+import com.beside.archivist.service.usergroup.UserGroupService;
 import com.beside.archivist.service.users.UserService;
 import com.beside.archivist.utils.JwtTokenUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,6 +32,7 @@ public class UserController {
 
     private final KakaoService kakaoServiceImpl;
     private final UserService userServiceImpl;
+    private final UserGroupService userGroupServiceImpl;
     private final JwtTokenUtil jwtTokenUtil;
 
     @PostMapping("/login/kakao")
@@ -58,6 +57,7 @@ public class UserController {
             throw new EmailTokenMismatchException(ExceptionCode.EMAIL_TOKEN_MISMATCH);
         }
         UserInfoDto savedUser = userServiceImpl.saveUser(userDto);
+        userGroupServiceImpl.saveDefaultGroup(savedUser.getEmail()); // 회원 가입 시 기본 그룹 자동 생성
         return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
     }
 

--- a/src/main/java/com/beside/archivist/dto/group/GroupInfoDto.java
+++ b/src/main/java/com/beside/archivist/dto/group/GroupInfoDto.java
@@ -3,8 +3,6 @@ package com.beside.archivist.dto.group;
 import com.beside.archivist.entity.group.Group;
 import com.beside.archivist.entity.users.Category;
 import com.querydsl.core.annotations.QueryProjection;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,9 +17,10 @@ public class GroupInfoDto {
     private List<Category> categories;  //그룹 카테고리
     private String imgUrl;
     private Long linkCount;
+    private String isDefault;
 
     @Builder
-    public GroupInfoDto(Long groupId, String groupName, String groupDesc, String isGroupPublic, List<Category> categories, String imgUrl, Long linkCount) {
+    public GroupInfoDto(Long groupId, String groupName, String groupDesc, String isGroupPublic, List<Category> categories, String imgUrl, Long linkCount, String isDefault) {
         this.groupId = groupId;
         this.groupName = groupName != null ? groupName.trim() : groupName;
         this.groupDesc = groupDesc;
@@ -29,6 +28,7 @@ public class GroupInfoDto {
         this.categories = categories;
         this.imgUrl = imgUrl;
         this.linkCount = linkCount;
+        this.isDefault = isDefault;
     }
 
     @QueryProjection
@@ -40,5 +40,6 @@ public class GroupInfoDto {
         this.categories = group.getCategories();
         this.imgUrl = group.getGroupImg().getImgUrl();
         this.linkCount = group.getLinkCount();
+        this.isDefault = group.getIsDefault();
     }
 }

--- a/src/main/java/com/beside/archivist/entity/group/Group.java
+++ b/src/main/java/com/beside/archivist/entity/group/Group.java
@@ -34,6 +34,8 @@ public class Group extends BaseEntity {
     private String isGroupPublic; // default: 'Y'
     @Column
     private List<Category> categories;
+    @Column
+    private String isDefault;
     @Formula("(SELECT COUNT(lg.link_group_id) FROM link_group lg WHERE lg.group_id = group_id)")
     private Long linkCount;
 
@@ -48,13 +50,14 @@ public class Group extends BaseEntity {
 
 
     @Builder
-    public Group(String groupName, String groupDesc, String isGroupPublic, List<Category> categories, Long linkCount, List<LinkGroup> linkGroups) {
+    public Group(String groupName, String groupDesc, String isGroupPublic, List<Category> categories, Long linkCount, List<LinkGroup> linkGroups, String isDefault) {
         this.groupName = groupName;
         this.groupDesc = groupDesc;
         this.isGroupPublic = isGroupPublic == null ? "Y" : isGroupPublic;
         this.categories = categories;
         this.linkCount = linkCount;
         this.linkGroups = linkGroups;
+        this.isDefault = isDefault == null ? "N" : isDefault;
     }
     public void update(GroupDto groupDto) {
         this.groupName = groupDto.getGroupName();
@@ -71,5 +74,14 @@ public class Group extends BaseEntity {
     }
     public void saveGroupImg(GroupImg groupImg){
         this.groupImg = groupImg;
+    }
+
+    public static Group fetchDefaultGroup() { // 기본 그룹 비공개
+        return Group.builder()
+                .groupName("기본 그룹")
+                .groupDesc("기본 그룹")
+                .isDefault("Y")
+                .isGroupPublic("N")
+                .build();
     }
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupService.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupService.java
@@ -24,4 +24,5 @@ public interface GroupService {
 
     void changeToLinkImg(Long groupId, LinkImg linkImg);
     List<GroupInfoDto> getAllGroups();
+    Group saveDefaultGroup();
 }

--- a/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/group/GroupServiceImpl.java
@@ -158,4 +158,17 @@ public class GroupServiceImpl implements GroupService {
                 .toList();
         return groupMapperImpl.toDtoList(groups);
     }
+
+    /**
+     * 회원별로 신규 가입 시 기본 그룹 자동 생성 ( 수정/삭제 X, 비공개 )
+     * @return
+     */
+    @Override
+    public Group saveDefaultGroup() {
+        Group defaultGroup = groupRepository.save(Group.fetchDefaultGroup());
+        GroupImg groupImg = GroupImg.initializeDefaultLinkImg();
+        groupImg.saveGroup(defaultGroup);
+        groupImgServiceImpl.saveGroupImg(groupImg);
+        return defaultGroup;
+    }
 }

--- a/src/main/java/com/beside/archivist/service/usergroup/UserGroupService.java
+++ b/src/main/java/com/beside/archivist/service/usergroup/UserGroupService.java
@@ -11,4 +11,5 @@ public interface UserGroupService {
     List<GroupInfoDto> getGroupDtoByUserId(Long userId, boolean isOwner);
     void deleteBookmark(Long userId, Long groupId);
     void checkDuplicateGroup(Long userId, Long groupId, boolean isOwner);
+    void saveDefaultGroup(String email);
 }

--- a/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
+++ b/src/main/java/com/beside/archivist/service/usergroup/UserGroupServiceImpl.java
@@ -31,8 +31,8 @@ public class UserGroupServiceImpl implements UserGroupService {
         
         UserGroup userGroup = UserGroup.builder()
                 .isOwner(isOwner) // save / bookmark 그룹 구분
-                .users(userServiceImpl.getUserByEmail(email))
-                .groups(groupServiceImpl.getGroup(groupId))
+                .users(findUser)
+                .groups(findGroup)
                 .build();
 
         userGroup.getUsers().addUserGroup(userGroup);
@@ -62,5 +62,19 @@ public class UserGroupServiceImpl implements UserGroupService {
             throw new GroupInBookmarkNotFoundException(ExceptionCode.GROUP_IN_BOOKMARK_NOT_FOUND);
         }
         userGroupRepository.delete(userGroup);
+    }
+
+    @Override
+    public void saveDefaultGroup(String email) {
+        User findUser = userServiceImpl.getUserByEmail(email);
+        Group defaultGroup = groupServiceImpl.saveDefaultGroup();
+
+        UserGroup userGroup = UserGroup.builder()
+                .groups(defaultGroup)
+                .users(findUser)
+                .isOwner(true)
+                .build();
+
+        userGroupRepository.save(userGroup);
     }
 }


### PR DESCRIPTION
회원 가입 시 기본 그룹 자동 생성 (#230)

### 주요 변경 사항
- Group Table 내 isDefault 필드 추가
- 회원 가입 API 내 기본 그룹 저장 로직 추가
- 해당 시나리오 테스트 코드 작성

### 고려 사항
- 수정 및 삭제 막는 건 FE 에서 처리해주신다고 합니다~