### PR TITLE
FE 오피셜 도메인 CORS 화이트리스트 추가

### DIFF
--- a/src/main/java/com/beside/archivist/config/SecurityConfig.java
+++ b/src/main/java/com/beside/archivist/config/SecurityConfig.java
@@ -88,7 +88,8 @@ public class SecurityConfig {
             "http://www.test.arcave-official.com",
             "http://www.stage.arcave-official.com",
             "https://archivist-frontend-web.vercel.app",
-            "https://archivist-frontend-pgonee.vercel.app"
+            "https://archivist-frontend-pgonee.vercel.app",
+            "https://app.arcave-official.com"
         ));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("*"));


### PR DESCRIPTION
FE 오피셜 도메인 CORS 화이트리스트 추가 (#235)

### 주요 변경 사항
- FE 오피셜 도메인 CORS 화이트리스트 추가

### 고려 사항
- 배포 확인 요망